### PR TITLE
Add extra NSINFO fields about write errors

### DIFF
--- a/libzdb/api.c
+++ b/libzdb/api.c
@@ -289,7 +289,7 @@ zdb_api_t *zdb_api_set(namespace_t *ns, void *key, size_t ksize, void *payload, 
         size_t limits = ns->maxsize + floating;
 
         // check if there is still enough space
-        if(ns->index->datasize + psize > limits)
+        if(ns->index->stats.datasize + psize > limits)
             return zdb_api_reply_error("No space left on this namespace");
     }
 

--- a/libzdb/data.c
+++ b/libzdb/data.c
@@ -71,6 +71,10 @@ static int data_write(int fd, void *buffer, size_t length, int syncer, data_root
         // update statistics
         zdb_rootsettings.stats.datawritefailed += 1;
 
+        // update namespace statistics
+        root->stats.errors += 1;
+        root->stats.lasterr = time(NULL);
+
         zdb_warnp("data write");
         return 0;
     }
@@ -533,6 +537,8 @@ data_root_t *data_init_lazy(zdb_settings_t *settings, char *datapath, uint16_t d
     root->synctime = settings->synctime;
     root->lastsync = 0;
     root->previous = 0;
+
+    memset(&root->stats, 0x00, sizeof(data_stats_t));
 
     data_set_id(root);
 

--- a/libzdb/data.h
+++ b/libzdb/data.h
@@ -4,17 +4,28 @@
     // split datafile after 256 MB
     #define ZDB_DEFAULT_DATA_MAXSIZE  256 * 1024 * 1024
 
+    // data statistics
+    typedef struct data_stats_t {
+        size_t hits;     // amount of data hit requested (not used yet)
+        size_t faults;   // amount of data hit missed (not used yet)
+        size_t errors;   // amount of io (read/write) error
+        time_t lasterr;  // last error timestamp
+
+    } data_stats_t;
+
+
     // root point of the memory handler
     // used by the data manager
     typedef struct data_root_t {
-        char *datadir;    // root path of the data files
-        char *datafile;   // pointer to the current datafile used
-        uint16_t dataid;  // id of the datafile currently in use
-        int datafd;       // file descriptor of the current datafile used
-        int sync;         // flag to force data write sync
-        int synctime;     // force to sync data after this timeout (on next write)
-        time_t lastsync;  // keep track when the last sync was explictly made
-        size_t previous;  // keep latest offset inserted to the datafile
+        char *datadir;      // root path of the data files
+        char *datafile;     // pointer to the current datafile used
+        uint16_t dataid;    // id of the datafile currently in use
+        int datafd;         // file descriptor of the current datafile used
+        int sync;           // flag to force data write sync
+        int synctime;       // force to sync data after this timeout (on next write)
+        time_t lastsync;    // keep track when the last sync was explictly made
+        size_t previous;    // keep latest offset inserted to the datafile
+        data_stats_t stats; // data statistics (session time)
 
     } data_root_t;
 

--- a/libzdb/index.h
+++ b/libzdb/index.h
@@ -140,6 +140,18 @@
 
     } index_seqid_t;
 
+    // index statistics
+    typedef struct index_stats_t {
+        size_t size;     // in memory index size usage (in bytes)
+        size_t datasize; // data payload size
+        size_t entries;  // keys count
+        size_t hits;     // amount of index hit requested (not used yet)
+        size_t faults;   // amount of index hit missed (not used yet)
+        size_t errors;   // amount of io (read/write) error
+        time_t lasterr;  // last error timestamp
+
+    } index_stats_t;
+
     //
     // global root memory structure of the index
     //
@@ -160,10 +172,7 @@
         index_seqid_t *seqid;      // sequential fileid mapping
         index_branch_t **branches; // list of branches explained later
         index_status_t status;     // index health
-
-        size_t datasize;    // statistics about size of data on disk
-        size_t indexsize;   // statistics about index in-memory size
-        size_t entries;     // statistics about number of keys for this index
+        index_stats_t stats;       // index statistics
 
         size_t previous;    // keep latest offset inserted to the indexfile
 
@@ -273,4 +282,7 @@
     void index_close(index_root_t *root);
 
     const char *index_modename(index_root_t *index);
+
+    // statistics management
+    void index_io_error(index_root_t *root);
 #endif

--- a/libzdb/index_loader.c
+++ b/libzdb/index_loader.c
@@ -52,7 +52,7 @@ static void index_dump(index_root_t *root, int fulldump) {
     }
 
     if(fulldump) {
-        if(root->entries == 0)
+        if(root->stats.entries == 0)
             printf("[+] index is empty\n");
 
         printf("[+] ===========================\n");
@@ -70,13 +70,13 @@ static void index_dump(index_root_t *root, int fulldump) {
 }
 
 static void index_dump_statistics(index_root_t *root) {
-    zdb_verbose("[+] index: load: %lu entries\n", root->entries);
+    zdb_verbose("[+] index: load: %lu entries\n", root->stats.entries);
 
-    double datamb = MB(root->datasize);
-    double indexkb = KB(root->indexsize);
+    double datamb = MB(root->stats.datasize);
+    double indexkb = KB(root->stats.size);
 
-    zdb_verbose("[+] index: datasize: " COLOR_CYAN "%.2f MB" COLOR_RESET " (%lu bytes)\n", datamb, root->datasize);
-    zdb_verbose("[+] index: raw usage: %.1f KB (%lu bytes)\n", indexkb, root->indexsize);
+    zdb_verbose("[+] index: datasize: " COLOR_CYAN "%.2f MB" COLOR_RESET " (%lu bytes)\n", datamb, root->stats.datasize);
+    zdb_verbose("[+] index: raw usage: %.1f KB (%lu bytes)\n", indexkb, root->stats.size);
 }
 
 //

--- a/libzdb/index_set.c
+++ b/libzdb/index_set.c
@@ -196,9 +196,9 @@ index_entry_t *index_insert_memory_handler_memkey(index_root_t *root, index_set_
 
     // update statistics (if the key exists)
     // maybe it doesn't exists if it comes from a replay
-    root->entries += 1;
-    root->datasize += new->length;
-    root->indexsize += entrysize;
+    root->stats.entries += 1;
+    root->stats.datasize += new->length;
+    root->stats.size += entrysize;
 
     // update next entry id
     root->nextentry += 1;
@@ -212,8 +212,8 @@ index_entry_t *index_insert_memory_handler_sequential(index_root_t *root, index_
 
     // update statistics (if the key exists)
     // maybe it doesn't exists if it comes from a replay
-    root->entries += 1;
-    root->datasize += new->length;
+    root->stats.entries += 1;
+    root->stats.datasize += new->length;
 
     // update next entry id
     root->nextentry += 1;
@@ -233,8 +233,8 @@ index_entry_t *index_update_memory_handler_memkey(index_root_t *root, index_set_
     zdb_debug("[+] index: updating current entry in memory\n");
 
     // update statistics
-    root->datasize -= exists->length;
-    root->datasize += new->length;
+    root->stats.datasize -= exists->length;
+    root->stats.datasize += new->length;
 
     // updating parent id and parent offset
     // to the previous item itself, which
@@ -269,16 +269,16 @@ index_entry_t *index_update_memory_handler_sequential(index_root_t *root, index_
         // blindly if exists is NULL (that means we comes from
         // 'index_set_memory' and we are not really doing some update
         // but more a replay from the index_loader
-        root->datasize += new->length;
-        root->entries += 1;
+        root->stats.datasize += new->length;
+        root->stats.entries += 1;
         return new;
     }
 
     // we have a previous key, this is a real
     // update and we need to reflect that on the statistics
     // there are no new entry, since it's an update
-    root->datasize -= exists->length;
-    root->datasize += new->length;
+    root->stats.datasize -= exists->length;
+    root->stats.datasize += new->length;
 
     return new;
 }

--- a/zdbd/commands_set.c
+++ b/zdbd/commands_set.c
@@ -290,7 +290,7 @@ int command_set(redis_client_t *client) {
         size_t limits = client->ns->maxsize + floating;
 
         // check if there is still enough space
-        if(index->datasize + request->argv[2]->length > limits) {
+        if(index->stats.datasize + request->argv[2]->length > limits) {
             redis_hardsend(client, "-No space left on this namespace");
             return 1;
         }


### PR DESCRIPTION
Add extra fields to NSINFO with extra errors indicators:

```
stats_index_io_errors: 0
stats_index_io_error_last: 0
stats_index_faults: 0
stats_data_io_errors: 26
stats_data_io_error_last: 1589898871
```

Theses stats are updated and incremented as soon as a write fails on index or data

This implement issue #75