### PR TITLE
Prefix all logs with boot time

### DIFF
--- a/libzdb/api.c
+++ b/libzdb/api.c
@@ -143,7 +143,6 @@ static zdb_api_t *api_set_handler_userkey(namespace_t *ns, void *key, size_t ksi
 
     zdb_debug("[+] api: set: userkey: ");
     zdb_debughex(key, ksize);
-    zdb_debug("\n");
 
     zdb_debug("[+] api: set: offset: %lu\n", offset);
 
@@ -225,7 +224,6 @@ static zdb_api_t *api_set_handler_sequential(namespace_t *ns, void *key, size_t 
 
     zdb_debug("[+] api: set: sequential-key: ");
     zdb_debughex(&id, idlength);
-    zdb_debug("\n");
 
     zdb_debug("[+] api: set: offset: %lu\n", offset);
 

--- a/libzdb/api.c
+++ b/libzdb/api.c
@@ -334,7 +334,7 @@ zdb_api_t *zdb_api_get(namespace_t *ns, void *key, size_t ksize) {
     data_payload_t payload = data_get(data, entry->offset, entry->length, entry->dataid, entry->idlength);
 
     if(!payload.buffer) {
-        printf("[-] api: get: cannot read payload\n");
+        zdb_log("[-] api: get: cannot read payload\n");
         free(payload.buffer);
         return zdb_api_reply(ZDB_API_INTERNAL_ERROR, NULL);
     }

--- a/libzdb/bootstrap.c
+++ b/libzdb/bootstrap.c
@@ -48,7 +48,7 @@ zdb_settings_t *zdb_initialize() {
 
     // initialize stats and init time
     memset(&s->stats, 0x00, sizeof(zdb_stats_t));
-    s->stats.inittime = time(NULL);
+    gettimeofday(&s->stats.inittime, NULL);
 
     // initialize instance id
     s->iid = zdb_instanceid_generate();

--- a/libzdb/data.c
+++ b/libzdb/data.c
@@ -269,7 +269,12 @@ static void data_open_final(data_root_t *root) {
 size_t data_jump_next(data_root_t *root, uint16_t newid) {
     zdb_verbose("[+] data: jumping to the next file\n");
 
+    // flushing data
+    zdb_log("[+] data: flushing file before closing\n");
+    fsync(root->datafd);
+
     // closing current file descriptor
+    zdb_log("[+] data: closing current datafile\n");
     close(root->datafd);
 
     // moving to the next file

--- a/libzdb/data.c
+++ b/libzdb/data.c
@@ -80,7 +80,7 @@ static int data_write(int fd, void *buffer, size_t length, int syncer, data_root
     }
 
     if(response != (ssize_t) length) {
-        fprintf(stderr, "[-] data write: partial write\n");
+        zdb_logerr("[-] data write: partial write\n");
         return 0;
     }
 
@@ -257,7 +257,7 @@ static void data_open_final(data_root_t *root) {
     }
 
     zdb_debug("[+] data: entries read: %d, last offset: %lu\n", entries, root->previous);
-    printf("[+] data: active file: %s\n", root->datafile);
+    zdb_log("[+] data: active file: %s\n", root->datafile);
 }
 
 // jumping to the next id close the current data file

--- a/libzdb/data.c
+++ b/libzdb/data.c
@@ -67,6 +67,8 @@ static inline int data_sync_check(data_root_t *root, int fd) {
 static int data_write(int fd, void *buffer, size_t length, int syncer, data_root_t *root) {
     ssize_t response;
 
+    zdb_debug("[+] data: writing %lu bytes to fd %d\n", length, fd);
+
     if((response = write(fd, buffer, length)) < 0) {
         // update statistics
         zdb_rootsettings.stats.datawritefailed += 1;
@@ -83,6 +85,8 @@ static int data_write(int fd, void *buffer, size_t length, int syncer, data_root
         zdb_logerr("[-] data write: partial write\n");
         return 0;
     }
+
+    zdb_debug("[+] data: wrote %lu bytes to fd %d\n", response, fd);
 
     // update statistics
     zdb_rootsettings.stats.datadiskwrite += length;

--- a/libzdb/index.c
+++ b/libzdb/index.c
@@ -306,7 +306,12 @@ size_t index_jump_next(index_root_t *root) {
         hook_append(hook, root->indexfile);
     }
 
+    // flushing current index file
+    zdb_log("[+] index: flushing file before closing\n");
+    fsync(root->indexfd);
+
     // closing current file descriptor
+    zdb_log("[+] index: closing current index file\n");
     index_close(root);
 
     // moving to the next file

--- a/libzdb/index.c
+++ b/libzdb/index.c
@@ -109,7 +109,7 @@ int index_write(int fd, void *buffer, size_t length, index_root_t *root) {
     }
 
     if(response != (ssize_t) length) {
-        fprintf(stderr, "[-] index write: partial write\n");
+        zdb_logerr("[-] index write: partial write\n");
         return 0;
     }
 
@@ -134,12 +134,12 @@ static int index_read(int fd, void *buffer, size_t length) {
     }
 
     if(response == 0) {
-        fprintf(stderr, "[-] index read: eof reached\n");
+        zdb_logerr("[-] index read: eof reached\n");
         return 0;
     }
 
     if(response != (ssize_t) length) {
-        fprintf(stderr, "[-] index read: partial read\n");
+        zdb_logerr("[-] index read: partial read\n");
         return 0;
     }
 
@@ -281,11 +281,11 @@ void index_open_final(index_root_t *root) {
 
     if((root->indexfd = open(root->indexfile, flags, 0600)) < 0) {
         zdb_warnp(root->indexfile);
-        fprintf(stderr, "[-] index: could not open index file\n");
+        zdb_logerr("[-] index: could not open index file\n");
         return;
     }
 
-    printf("[+] index: active file: %s\n", root->indexfile);
+    zdb_log("[+] index: active file: %s\n", root->indexfile);
 }
 
 void index_close(index_root_t *root) {
@@ -669,9 +669,9 @@ static inline size_t index_clean_namespace_branch(index_branch_t *branch, void *
         }
 
         #ifndef RELEASE
-        printf("[+] index: namespace cleaner: free: ");
+        zdb_log("[+] index: namespace cleaner: free: ");
         zdb_hexdump(entry->id, entry->idlength);
-        printf("\n");
+        printf("\n"); // FIXME
         #endif
 
         // okay, we need to remove this key

--- a/libzdb/index_get.c
+++ b/libzdb/index_get.c
@@ -67,7 +67,6 @@ index_entry_t *index_get(index_root_t *index, void *id, uint8_t idlength) {
 
     zdb_debug("[+] index: get: lookup key: ");
     zdb_debughex(id, idlength);
-    zdb_debug("\n");
 
     if(!(entry = index_get_handlers[index->mode](index, id, idlength))) {
         zdb_debug("[-] index: get: key not found\n");

--- a/libzdb/index_loader.c
+++ b/libzdb/index_loader.c
@@ -17,9 +17,9 @@
 // index initializer and dumper
 //
 static inline void index_dump_entry(index_entry_t *entry) {
-    printf("[+] key [");
+    zdb_log("[+] key [");
     zdb_hexdump(entry->id, entry->idlength);
-    printf("] offset %" PRIu32 ", length: %" PRIu32 "\n", entry->offset, entry->length);
+    zdb_log("] offset %" PRIu32 ", length: %" PRIu32 "\n", entry->offset, entry->length);
 }
 
 // dumps the current index load
@@ -27,10 +27,10 @@ static inline void index_dump_entry(index_entry_t *entry) {
 static void index_dump(index_root_t *root, int fulldump) {
     size_t branches = 0;
 
-    printf("[+] index: verifyfing populated keys\n");
+    zdb_log("[+] index: verifyfing populated keys\n");
 
     if(fulldump)
-        printf("[+] ===========================\n");
+        zdb_log("[+] ===========================\n");
 
     // iterating over each buckets
     for(uint32_t b = 0; b < buckets_branches; b++) {
@@ -53,9 +53,9 @@ static void index_dump(index_root_t *root, int fulldump) {
 
     if(fulldump) {
         if(root->stats.entries == 0)
-            printf("[+] index is empty\n");
+            zdb_log("[+] index is empty\n");
 
-        printf("[+] ===========================\n");
+        zdb_log("[+] ===========================\n");
     }
 
     zdb_verbose("[+] index: uses: %lu branches\n", branches);
@@ -203,8 +203,8 @@ static size_t index_load_file(index_root_t *root) {
             // we read something, but not the expected header, at least
             // not this amount of data, which is a completly undefined behavior
             // let's just stopping here
-            fprintf(stderr, "[-] index: header corrupted or incomplete\n");
-            fprintf(stderr, "[-] index: expected %lu bytes, %ld read\n", sizeof(index_header_t), length);
+            zdb_logerr("[-] index: header corrupted or incomplete\n");
+            zdb_logerr("[-] index: expected %lu bytes, %ld read\n", sizeof(index_header_t), length);
             exit(EXIT_FAILURE);
         }
 
@@ -225,12 +225,12 @@ static size_t index_load_file(index_root_t *root) {
         // and it's empty, there is no goal to do anything
         // let's crash
         if(root->status & INDEX_READ_ONLY) {
-            fprintf(stderr, "[-] no index found and readonly filesystem\n");
-            fprintf(stderr, "[-] cannot starts correctly\n");
+            zdb_logerr("[-] no index found and readonly filesystem\n");
+            zdb_logerr("[-] cannot starts correctly\n");
             exit(EXIT_FAILURE);
         }
 
-        printf("[+] index: creating empty file\n");
+        zdb_log("[+] index: creating empty file\n");
         header = index_initialize(root->indexfd, root->indexid, root);
     }
 
@@ -265,7 +265,7 @@ static size_t index_load_file(index_root_t *root) {
         }
     }
 
-    printf("[+] index: populating: %s\n", root->indexfile);
+    zdb_log("[+] index: populating: %s\n", root->indexfile);
 
     // index seems in a good state
     // let's load it completely in memory now

--- a/libzdb/index_seq.c
+++ b/libzdb/index_seq.c
@@ -84,7 +84,7 @@ size_t index_seq_offset(uint32_t relative) {
 void index_seqid_dump(index_root_t *root) {
     for(uint16_t i = 0; i < root->seqid->length; i++) {
         index_seqmap_t *item = &root->seqid->seqmap[i];
-        printf("[+] index seq: seqid %d -> file %d\n", item->seqid, item->fileid);
+        zdb_log("[+] index seq: seqid %d -> file %d\n", item->seqid, item->fileid);
     }
 }
 

--- a/libzdb/libzdb.c
+++ b/libzdb/libzdb.c
@@ -93,6 +93,7 @@ void zdb_tools_hexdump(void *input, size_t length) {
 // global warning and fatal message
 //
 void *zdb_warnp(char *str) {
+    zdb_timelog();
     fprintf(stderr, "[-] %s: %s\n", str, strerror(errno));
     return NULL;
 }

--- a/libzdb/libzdb.c
+++ b/libzdb/libzdb.c
@@ -80,7 +80,7 @@ void zdb_hexdump(void *input, size_t length) {
         *writer++ = __hex[buffer[i] & 0x0F];
     }
 
-    printf("0x%s", output);
+    printf("0x%s\n", output);
     free(output);
 }
 

--- a/libzdb/libzdb.c
+++ b/libzdb/libzdb.c
@@ -9,7 +9,7 @@
 #include <execinfo.h>
 #include <getopt.h>
 #include <ctype.h>
-#include <time.h>
+#include <sys/time.h>
 #include "libzdb.h"
 #include "libzdb_private.h"
 
@@ -112,6 +112,19 @@ void zdb_verbosep(char *prefix, char *str) {
 void zdb_diep(char *str) {
     zdb_warnp(str);
     exit(EXIT_FAILURE);
+}
+
+void zdb_timelog() {
+    struct timeval n, *b;
+    double value = 0;
+
+    // boot time
+    b = &zdb_rootsettings.stats.inittime;
+
+    gettimeofday(&n, NULL);
+    value = (double)(n.tv_usec - b->tv_usec) / 1000000 + (double)(n.tv_sec - b->tv_sec);
+
+    printf("[% 15.7f]", value);
 }
 
 char *zdb_header_date(uint32_t epoch, char *target, size_t length) {

--- a/libzdb/libzdb.c
+++ b/libzdb/libzdb.c
@@ -124,7 +124,7 @@ void zdb_timelog() {
     gettimeofday(&n, NULL);
     value = (double)(n.tv_usec - b->tv_usec) / 1000000 + (double)(n.tv_sec - b->tv_sec);
 
-    printf("[% 15.7f]", value);
+    printf("[% 15.6f]", value);
 }
 
 char *zdb_header_date(uint32_t epoch, char *target, size_t length) {

--- a/libzdb/libzdb.h
+++ b/libzdb/libzdb.h
@@ -43,7 +43,7 @@
     #define ZDB_VERSION     "1.1.0"
 
     typedef struct zdb_stats_t {
-        time_t inittime;          // timestamp when zdb started (used for uptime)
+        struct timeval inittime;  // timestamp when zdb started (used for uptime)
 
         // index
         uint64_t idxreadfailed;   // amount of index disk read failure
@@ -107,6 +107,7 @@
     void zdb_tools_hexdump(void *input, size_t length);
     char *zdb_header_date(uint32_t epoch, char *target, size_t length);
 
+    void zdb_timelog();
     void *zdb_warnp(char *str);
     void zdb_diep(char *str);
 
@@ -116,10 +117,13 @@
     #define COLOR_CYAN   "\033[36;1m"
     #define COLOR_RESET  "\033[0m"
 
-    #define zdb_danger(fmt, ...)  { printf(COLOR_RED    fmt COLOR_RESET "\n", ##__VA_ARGS__); }
-    #define zdb_warning(fmt, ...) { printf(COLOR_YELLOW fmt COLOR_RESET "\n", ##__VA_ARGS__); }
-    #define zdb_success(fmt, ...) { printf(COLOR_GREEN  fmt COLOR_RESET "\n", ##__VA_ARGS__); }
-    #define zdb_notice(fmt, ...)  { printf(COLOR_CYAN   fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdb_log(fmt, ...)     { zdb_timelog(); printf(fmt, ##__VA_ARGS__); }
+    #define zdb_logerr(fmt, ...)  { zdb_timelog(); fprintf(stderr, fmt, ##__VA_ARGS__); }
+
+    #define zdb_danger(fmt, ...)  { zdb_timelog(); printf(COLOR_RED    fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdb_warning(fmt, ...) { zdb_timelog(); printf(COLOR_YELLOW fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdb_success(fmt, ...) { zdb_timelog(); printf(COLOR_GREEN  fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdb_notice(fmt, ...)  { zdb_timelog(); printf(COLOR_CYAN   fmt COLOR_RESET "\n", ##__VA_ARGS__); }
 
     #define KB(x)   (x / (1024.0))
     #define MB(x)   (x / (1024 * 1024.0))

--- a/libzdb/libzdb_private.h
+++ b/libzdb/libzdb_private.h
@@ -5,11 +5,11 @@
     void zdb_fulldump(void *data, size_t len);
 
     #ifndef RELEASE
-        #define zdb_verbose(...) { printf(__VA_ARGS__); }
-        #define zdb_debug(...) { printf(__VA_ARGS__); }
+        #define zdb_verbose(...)  { zdb_timelog(); printf(__VA_ARGS__); }
+        #define zdb_debug(...)    { zdb_timelog(); printf(__VA_ARGS__); }
         #define zdb_debughex(...) { zdb_hexdump(__VA_ARGS__); }
     #else
-        #define zdb_verbose(...) { if(zdb_rootsettings.verbose) { printf(__VA_ARGS__); } }
+        #define zdb_verbose(...) { if(zdb_rootsettings.verbose) { zdb_timelog(); printf(__VA_ARGS__); } }
         #define zdb_debug(...) ((void)0)
         #define zdb_debughex(...) ((void)0)
     #endif

--- a/libzdb/namespace.c
+++ b/libzdb/namespace.c
@@ -725,10 +725,10 @@ int namespaces_emergency() {
     namespace_t *ns;
 
     for(ns = namespace_iter(); ns; ns = namespace_iter_next(ns)) {
-        printf("[+] namespaces: flushing index [%s]\n", ns->name);
+        zdb_log("[+] namespaces: flushing index [%s]\n", ns->name);
 
         if(index_emergency(ns->index)) {
-            printf("[+] namespaces: flushing data [%s]\n", ns->name);
+            zdb_log("[+] namespaces: flushing data [%s]\n", ns->name);
             // only flusing data if index flush was accepted
             // if index flush returns 0, we are probably in an initializing stage
             data_emergency(ns->data);

--- a/zdbd/commands.c
+++ b/zdbd/commands.c
@@ -149,7 +149,7 @@ int redis_dispatcher(redis_client_t *client) {
     }
 
     // unknown command
-    printf("[-] command: unsupported redis command\n");
+    zdb_log("[-] command: unsupported redis command\n");
     zdbd_rootsettings.stats.cmdsfailed += 1;
 
     // reset executed flag, this was a non-existing command

--- a/zdbd/commands_dataset.c
+++ b/zdbd/commands_dataset.c
@@ -19,7 +19,7 @@ int command_exists(redis_client_t *client) {
         return 1;
 
     if(request->argv[1]->length > MAX_KEY_LENGTH) {
-        printf("[-] invalid key size\n");
+        zdb_log("[-] command: exists: invalid key size\n");
         redis_hardsend(client, "-Invalid key");
         return 1;
     }
@@ -56,7 +56,7 @@ int command_check(redis_client_t *client) {
         return 1;
 
     if(request->argv[1]->length > MAX_KEY_LENGTH) {
-        printf("[-] invalid key size\n");
+        zdb_log("[-] command: check: invalid key size\n");
         redis_hardsend(client, "-Invalid key");
         return 1;
     }
@@ -104,7 +104,7 @@ int command_del(redis_client_t *client) {
         return 1;
 
     if(request->argv[1]->length > MAX_KEY_LENGTH) {
-        printf("[-] command: del: invalid key size\n");
+        zdb_log("[-] command: del: invalid key size\n");
         redis_hardsend(client, "-Invalid key");
         return 1;
     }

--- a/zdbd/commands_dataset.c
+++ b/zdbd/commands_dataset.c
@@ -26,7 +26,6 @@ int command_exists(redis_client_t *client) {
 
     zdbd_debug("[+] command: exists: lookup key: ");
     zdbd_debughex(request->argv[1]->buffer, request->argv[1]->length);
-    zdbd_debug("\n");
 
     index_root_t *index = client->ns->index;
     index_entry_t *entry = index_get(index, request->argv[1]->buffer, request->argv[1]->length);
@@ -63,7 +62,6 @@ int command_check(redis_client_t *client) {
 
     zdbd_debug("[+] command: check: lookup key: ");
     zdbd_debughex(request->argv[1]->buffer, request->argv[1]->length);
-    zdbd_debug("\n");
 
     index_root_t *index = client->ns->index;
     index_entry_t *entry = index_get(index, request->argv[1]->buffer, request->argv[1]->length);

--- a/zdbd/commands_get.c
+++ b/zdbd/commands_get.c
@@ -47,7 +47,7 @@ int command_get(redis_client_t *client) {
     data_payload_t payload = data_get(data, entry->offset, entry->length, entry->dataid, entry->idlength);
 
     if(!payload.buffer) {
-        printf("[-] command: get: cannot read payload\n");
+        zdb_log("[-] command: get: cannot read payload\n");
         redis_hardsend(client, "-Internal Error");
         free(payload.buffer);
         return 0;

--- a/zdbd/commands_history.c
+++ b/zdbd/commands_history.c
@@ -108,7 +108,7 @@ int history_send(redis_client_t *client, index_item_t *item, index_ekey_t *ekey)
     response.payload = data_get(data, item->offset, item->length, item->dataid, item->idlength);
 
     if(!response.payload.buffer) {
-        printf("[-] command: history: cannot read payload\n");
+        zdb_log("[-] command: history: cannot read payload\n");
         redis_hardsend(client, "-Internal Error");
         free(response.payload.buffer);
         return 0;

--- a/zdbd/commands_set.c
+++ b/zdbd/commands_set.c
@@ -81,7 +81,6 @@ static size_t redis_set_handler_userkey(redis_client_t *client, index_entry_t *e
 
     zdbd_debug("[+] command: set: userkey: ");
     zdbd_debughex(id, idlength);
-    zdbd_debug("\n");
 
     zdbd_debug("[+] command: set: offset: %lu\n", offset);
 
@@ -185,7 +184,6 @@ static size_t redis_set_handler_sequential(redis_client_t *client, index_entry_t
 
     zdbd_debug("[+] command: set: sequential-key: ");
     zdbd_debughex(&id, idlength);
-    zdbd_debug("\n");
 
     zdbd_debug("[+] command: set: offset: %lu\n", offset);
 

--- a/zdbd/commands_system.c
+++ b/zdbd/commands_system.c
@@ -88,17 +88,19 @@ int command_stop(redis_client_t *client) {
 
 int command_info(redis_client_t *client) {
     char info[4096];
+    struct timeval current;
     zdb_settings_t *zdb_settings = zdb_settings_get();
     zdb_stats_t *lstats = &zdb_settings->stats;
     zdbd_stats_t *dstats = &zdbd_rootsettings.stats;
+    gettimeofday(&current, NULL);
 
     sprintf(info, "# server\n");
     sprintf(info + strlen(info), "server_name: 0-db (zdb)\n");
     sprintf(info + strlen(info), "server_revision: " ZDBD_REVISION "\n");
     sprintf(info + strlen(info), "engine_revision: %s\n", zdb_revision());
     sprintf(info + strlen(info), "instance_id: %u\n", zdb_instanceid_get());
-    sprintf(info + strlen(info), "boot_time: %ld\n", dstats->boottime);
-    sprintf(info + strlen(info), "uptime: %ld\n", time(NULL) - dstats->boottime);
+    sprintf(info + strlen(info), "boot_time: %ld\n", dstats->boottime.tv_sec);
+    sprintf(info + strlen(info), "uptime: %ld\n", current.tv_sec - dstats->boottime.tv_sec);
 
 
     sprintf(info + strlen(info), "\n# clients\n");

--- a/zdbd/socket_epoll.c
+++ b/zdbd/socket_epoll.c
@@ -95,7 +95,7 @@ static int socket_event(struct epoll_event *events, int notified, redis_handler_
 
             // (dirty) way the STOP event is handled
             if(ctrl == RESP_STATUS_SHUTDOWN) {
-                printf("[+] stopping daemon\n");
+                zdb_log("[+] stopping daemon\n");
 
                 for(int i = 0; i < redis->fdlen; i++)
                     close(redis->mainfd[i]);

--- a/zdbd/socket_kqueue.c
+++ b/zdbd/socket_kqueue.c
@@ -91,7 +91,7 @@ static int socket_event(struct kevent *events, int notified, redis_handler_t *re
 
             // (dirty) way the STOP event is handled
             if(ctrl == RESP_STATUS_SHUTDOWN) {
-                printf("[+] stopping daemon\n");
+                zdb_log("[+] stopping daemon\n");
 
                 for(int i = 0; i < redis->fdlen; i++)
                     close(redis->mainfd[i]);

--- a/zdbd/zdbd.c
+++ b/zdbd/zdbd.c
@@ -100,7 +100,7 @@ void zdbd_hexdump(void *input, size_t length) {
         *writer++ = __hex[buffer[i] & 0x0F];
     }
 
-    printf("0x%s", output);
+    printf("0x%s\n", output);
     free(output);
 }
 

--- a/zdbd/zdbd.c
+++ b/zdbd/zdbd.c
@@ -145,7 +145,7 @@ void zdbd_timelog() {
     gettimeofday(&n, NULL);
     value = (double)(n.tv_usec - b->tv_usec) / 1000000 + (double)(n.tv_sec - b->tv_sec);
 
-    printf("[% 15.7f]", value);
+    printf("[% 15.6f]", value);
 }
 
 // internal id generatir

--- a/zdbd/zdbd.c
+++ b/zdbd/zdbd.c
@@ -108,6 +108,7 @@ void zdbd_hexdump(void *input, size_t length) {
 // global warning and fatal message
 //
 void *zdbd_warnp(char *str) {
+    zdbd_timelog();
     fprintf(stderr, "[-] %s: %s\n", str, strerror(errno));
     return NULL;
 }

--- a/zdbd/zdbd.h
+++ b/zdbd/zdbd.h
@@ -71,7 +71,7 @@
     #ifndef RELEASE
         #define zdbd_verbose(...)  { zdbd_timelog(); printf(__VA_ARGS__); }
         #define zdbd_debug(...)    { zdbd_timelog(); printf(__VA_ARGS__); }
-        #define zdbd_debughex(...) { zdbd_timelog(); zdbd_hexdump(__VA_ARGS__); }
+        #define zdbd_debughex(...) { zdbd_hexdump(__VA_ARGS__); }
     #else
         #define zdbd_verbose(...) { if(zdbd_rootsettings.verbose) { zdbd_timelog(); printf(__VA_ARGS__); } }
         #define zdbd_debug(...) ((void)0)

--- a/zdbd/zdbd.h
+++ b/zdbd/zdbd.h
@@ -26,7 +26,9 @@
     #define ZDBD_VERSION     "1.0.0"
 
     typedef struct zdbd_stats_t {
-        time_t boottime;          // timestamp when zdb started (used for uptime)
+        // boottime is kept for zdbd uptime statistics (for INFO command)
+        // but we use the libzdb inittime for logs
+        struct timeval boottime;  // timestamp when zdb started
         uint32_t clients;         // lifetime amount of clients connected
 
         // commands
@@ -58,23 +60,27 @@
     void zdbd_hexdump(void *buffer, size_t length);
     void zdbd_fulldump(void *data, size_t len);
 
-    #define zdbd_danger(fmt, ...)  { printf(COLOR_RED    fmt COLOR_RESET "\n", ##__VA_ARGS__); }
-    #define zdbd_warning(fmt, ...) { printf(COLOR_YELLOW fmt COLOR_RESET "\n", ##__VA_ARGS__); }
-    #define zdbd_success(fmt, ...) { printf(COLOR_GREEN  fmt COLOR_RESET "\n", ##__VA_ARGS__); }
-    #define zdbd_notice(fmt, ...)  { printf(COLOR_CYAN   fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdbd_log(fmt, ...)     { zdbd_timelog(); printf(fmt, ##__VA_ARGS__); }
+    #define zdbd_logerr(fmt, ...)  { zdbd_timelog(); fprintf(stderr, fmt, ##__VA_ARGS__); }
+
+    #define zdbd_danger(fmt, ...)  { zdbd_timelog(); printf(COLOR_RED    fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdbd_warning(fmt, ...) { zdbd_timelog(); printf(COLOR_YELLOW fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdbd_success(fmt, ...) { zdbd_timelog(); printf(COLOR_GREEN  fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdbd_notice(fmt, ...)  { zdbd_timelog(); printf(COLOR_CYAN   fmt COLOR_RESET "\n", ##__VA_ARGS__); }
 
     #ifndef RELEASE
-        #define zdbd_verbose(...) { printf(__VA_ARGS__); }
-        #define zdbd_debug(...) { printf(__VA_ARGS__); }
-        #define zdbd_debughex(...) { zdbd_hexdump(__VA_ARGS__); }
+        #define zdbd_verbose(...)  { zdbd_timelog(); printf(__VA_ARGS__); }
+        #define zdbd_debug(...)    { zdbd_timelog(); printf(__VA_ARGS__); }
+        #define zdbd_debughex(...) { zdbd_timelog(); zdbd_hexdump(__VA_ARGS__); }
     #else
-        #define zdbd_verbose(...) { if(zdbd_rootsettings.verbose) { printf(__VA_ARGS__); } }
+        #define zdbd_verbose(...) { if(zdbd_rootsettings.verbose) { zdbd_timelog(); printf(__VA_ARGS__); } }
         #define zdbd_debug(...) ((void)0)
         #define zdbd_debughex(...) ((void)0)
     #endif
 
     extern zdbd_settings_t zdbd_rootsettings;
 
+    void zdbd_timelog();
     void zdbd_diep(char *str);
     void zdbd_dieg(char *str, int status);
     void *zdbd_warnp(char *str);


### PR DESCRIPTION
Improve debugging output with boot time prefixed:
```
[       0.000009][*] 0-db engine, v1.1.0 (commit 73f7447b)
[       0.000158][*] 0-db server, v1.0.0 (commit 73f7447b)
[       0.000174][+] system: running mode: mixed mode
[       0.000179][+] system: maximum namespace size: 16384.00 GB
[       0.000186][+] system: instance id: 773039487
[       0.000191][+] system: setting up environments
[       0.000215][+] namespaces: initializing
[       0.000223][+] namespaces: pre-allocating index (16777216 lazy branches)
[       0.000240][+] namespaces: loading 'default'
[       0.000250][+] namespaces: checking index [/mnt/storage/tmp/zdb-master-index/default]
[       0.000257][+] namespaces: checking data [/mnt/storage/tmp/zdb-master-data/default]
[       0.000278][+] namespace: loaded: default
[       0.000285][+] -> maxsize: 0 (0.00 MB)
[       0.000293][+] -> password protection: no
[       0.000298][+] -> public access: yes
[       0.000306][+] -> worm mode: no
[       0.000316][+] index: initializing
[       0.000337][+] index: loading file: /mnt/storage/tmp/zdb-master-index/default/zdb-index-00000
[       0.000350][+] index: running mode: default key-value
[       0.000359][+] index: writing 27 bytes on fd 3
[       0.000399][+] index: created at: 2020-07-11 02:33:05
[       0.000468][+] index: last open: 2020-08-06 12:15:42
[       0.000484][+] index: populating: /mnt/storage/tmp/zdb-master-index/default/zdb-index-00000
[       0.000491][+] index: loading in memory file: 0.00 MB
[       0.000499][+] index: get: lookup key: 0x68656c6c6f[       0.000502]
[       0.000515][-] index: get: key not found
[       0.000536][+] index: last offset: 27
[       0.000546][+] index: healthy
[       0.000557][+] index: active file: /mnt/storage/tmp/zdb-master-index/default/zdb-index-00000
[       0.000563][+] index: verifyfing populated keys
[       0.059712][+] index: uses: 1 branches
[       0.059721][+] index: memory overhead: 131072.02 KB (134217752 bytes)
[       0.059724][+] index: load: 1 entries
[       0.059725][+] index: datasize: 0.00 MB (5 bytes)
[       0.059726][+] index: raw usage: 0.1 KB (61 bytes)
[       0.059755][+] data: reading file, finding last entry
[       0.059758][+] data: entries read: 1, last offset: 26
[       0.059760][+] data: active file: /mnt/storage/tmp/zdb-master-data/default/zdb-data-00000
[       0.059772][+] namespaces: extra found: maxux
[       0.059774][+] namespaces: loading 'maxux'
[       0.059775][+] namespaces: checking index [/mnt/storage/tmp/zdb-master-index/maxux]
[       0.059778][+] namespaces: checking data [/mnt/storage/tmp/zdb-master-data/maxux]
[       0.059781][+] namespace: loaded: maxux
[       0.059782][+] -> maxsize: 0 (0.00 MB)
[       0.059784][+] -> password protection: no
[       0.059784][+] -> public access: yes
[       0.059785][+] -> worm mode: no
[       0.059786][+] index: initializing
[       0.059791][+] index: loading file: /mnt/storage/tmp/zdb-master-index/maxux/zdb-index-00000
[       0.059793][+] index: running mode: sequential keys
[       0.059794][+] index: writing 27 bytes on fd 6
[       0.059798][+] index: created at: 2020-07-11 02:33:09
[       0.059807][+] index: last open: 2020-08-06 12:15:42
[       0.059809][+] index: populating: /mnt/storage/tmp/zdb-master-index/maxux/zdb-index-00000
[       0.059811][+] index: loading in memory file: 0.00 MB
[       0.059813][+] index: last offset: 0
[       0.059815][+] index: healthy
[       0.059817][+] index: active file: /mnt/storage/tmp/zdb-master-index/maxux/zdb-index-00000
[       0.059819][+] index: verifyfing populated keys
[       0.117907][+] index: uses: 1 branches
[       0.117915][+] index: memory overhead: 131072.02 KB (134217752 bytes)
[       0.117917][+] index: load: 0 entries
[       0.117918][+] index: datasize: 0.00 MB (0 bytes)
[       0.117919][+] index: raw usage: 0.0 KB (0 bytes)
[       0.117944][+] data: reading file, finding last entry
[       0.117945][+] data: entries read: 0, last offset: 0
[       0.117947][+] data: active file: /mnt/storage/tmp/zdb-master-data/maxux/zdb-data-00000
[       0.117948][+] namespace: allocating new slot
[       0.117954][+] namespaces: 1 extra namespaces loaded
[       0.117956][+] network: looking for: host: ::, port: 9900
[       0.117971][+] listen request: tcp://:::9900 (fd: 5)
[       0.117976][+] listening on socket 5
[       2.347616][+] new client (fd: 9)
[       2.347664][+] incoming connection (socket 9)
[       2.347676][+] redis: nothing to send to client (fd: 9)
[       2.347977][+] redis: resp: 1 arguments
[       2.348002][+] redis: request parsed, calling dispatcher
[       2.348007][+] command: request fd: 9, namespace: default
[       2.348012][+] command: 'COMMAND' [+0 args]
[       2.348030][-] command: unsupported redis command
[       2.348035][+] redis: sending reply to 9 (24 bytes remains)
[       2.348090][+] redis: send: buffer sucessfully sent
[       2.348099][+] redis: dispatcher done, return code: 1
[       2.348107][+] redis: calling posthandler
[       2.348118][+] redis: nothing to send to client (fd: 9)
[       3.391307][+] redis: resp: 1 arguments
[       3.391337][+] redis: request parsed, calling dispatcher
[       3.391347][+] command: request fd: 9, namespace: default
[       3.391358][+] command: 'info' [+0 args]
[       3.391413][+] redis: sending reply to 9 (641 bytes remains)
[       3.391493][+] redis: send: buffer sucessfully sent
[       3.391507][+] redis: dispatcher done, return code: 0
[       3.391516][+] redis: calling posthandler
[       3.391525][+] redis: nothing to send to client (fd: 9)
[       5.575180][+] resp: empty socket read, client disconnected
[       5.575211][+] client: closing (fd: 9)
[       5.575223][+] client: stayed 4 seconds, 2 commands
^C[       6.510535][+] signal: request cleaning
[       6.510552][+] namespaces: flushing index [default]
[       6.519736][+] namespaces: flushing data [default]
[       6.526990][+] namespaces: flushing index [maxux]
[       6.533584][+] namespaces: flushing data [maxux]
```