### PR TITLE
redis: ensure all sockets are closed and free'd on exit

### DIFF
--- a/zdbd/redis.c
+++ b/zdbd/redis.c
@@ -1297,6 +1297,10 @@ int redis_listen(char *listenaddr, char *port, char *socket) {
         if(clients.list[i])
             socket_client_free(i);
 
+    for(int i = 0; i < fdindex; i++)
+        close(redis.mainfd[i]);
+
+    free(redis.mainfd);
     free(clients.list);
 
     // notifing source that we are done


### PR DESCRIPTION
Small memory fix, which doesn't impact anything on production, it's just for a better `valgrind` reports.