### PR TITLE
core: hotfix before moving to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,11 +439,13 @@ Current supported hooks:
 | --------------------- | ----------------------- | -------------------------- |
 | `ready`               | Server is ready         | (none)                     |
 | `close`               | Server closing (nicely) | (none)                     |
-| `jump`                | Data/Index incremented  | Closing and New index file |
+| `jump-index`          | Index incremented       | Closing and new index file |
+| `jump-data`           | Data incremented        | Closing and new data file  |
 | `crash`               | Server crashed          | (none)                     |
 | `namespace-created`   | New namespace created   | Namespace name             |
 | `namespace-deleted`   | Namespace removed       | Namespace name             |
 | `namespace-reloaded`  | Namespace reloaded      | Namespace name             |
+| `missing-data`        | Data file not found     | Missing filename           |
 
 # Limitation
 By default, datafiles are split when bigger than 256 MB.

--- a/libzdb/hook.h
+++ b/libzdb/hook.h
@@ -14,6 +14,7 @@
 
     hook_t *hook_new(char *name, size_t argc);
     int hook_append(hook_t *hook, char *argument);
-    int hook_execute(hook_t *hook);
+    pid_t hook_execute(hook_t *hook);
+    int hook_execute_wait(hook_t *hook);
     void hook_free(hook_t *hook);
 #endif

--- a/libzdb/index.c
+++ b/libzdb/index.c
@@ -497,7 +497,7 @@ int index_entry_delete_disk(index_root_t *root, index_entry_t *entry) {
     entry->flags |= INDEX_ENTRY_DELETED;
 
     // (re-)open the expected index file, in read-write mode
-    if((fd = index_open_file_readwrite(root, entry->dataid)) < 0)
+    if((fd = index_open_file_readwrite(root, entry->indexid)) < 0)
         return 1;
 
     // jump to the right offset for this entry

--- a/libzdb/index.c
+++ b/libzdb/index.c
@@ -303,7 +303,7 @@ size_t index_jump_next(index_root_t *root) {
     zdb_verbose("[+] index: jumping to the next file\n");
 
     if(zdb_rootsettings.hook) {
-        hook = hook_new("jump", 4);
+        hook = hook_new("jump-index", 4);
         hook_append(hook, zdb_rootsettings.zdbid);
         hook_append(hook, root->indexfile);
     }

--- a/libzdb/index.c
+++ b/libzdb/index.c
@@ -456,6 +456,11 @@ index_entry_t *index_reusable_entry = NULL;
 //     we do this in the index file and not in the data file so we keep
 //     the data file really always append in any case
 int index_entry_delete_memory(index_root_t *root, index_entry_t *entry) {
+    // updating statistics
+    root->stats.entries -= 1;
+    root->stats.datasize -= entry->length;
+    root->stats.size -= sizeof(index_entry_t) + entry->idlength;
+
     // running in a mode without index, let's just skip this
     if(root->branches == NULL)
         return 0;
@@ -474,11 +479,6 @@ int index_entry_delete_memory(index_root_t *root, index_entry_t *entry) {
 
     // removing entry from global branch
     index_branch_remove(branch, entry, previous);
-
-    // updating statistics
-    root->stats.entries -= 1;
-    root->stats.datasize -= entry->length;
-    root->stats.size -= sizeof(index_entry_t) + entry->idlength;
 
     // cleaning memory object
     free(entry);

--- a/libzdb/index_set.c
+++ b/libzdb/index_set.c
@@ -268,10 +268,6 @@ index_entry_t *index_update_memory_handler_sequential(index_root_t *root, index_
     root->nextentry += 1;
     root->nextid += 1;
 
-    // nothing to do if the key is deleted
-    if(index_entry_is_deleted(new))
-        return new;
-
     // key is not deleted, let's update statistics
     if(!exists) {
         // blindly if exists is NULL (that means we comes from
@@ -281,6 +277,10 @@ index_entry_t *index_update_memory_handler_sequential(index_root_t *root, index_
         root->stats.entries += 1;
         return new;
     }
+
+    // nothing to do if the key is deleted
+    if(index_entry_is_deleted(new))
+        return new;
 
     // we have a previous key, this is a real
     // update and we need to reflect that on the statistics
@@ -341,6 +341,10 @@ index_entry_t *index_update_entry_sequential(index_root_t *root, index_set_t *se
     // to be incremented to skip this position in the futur
     root->nextid += 1;
     root->nextentry += 1;
+
+    // update statistics
+    root->stats.datasize -= previous->length;
+    root->stats.datasize += set->entry->length;
 
     return set->entry;
 }

--- a/zdbd/commands_dataset.c
+++ b/zdbd/commands_dataset.c
@@ -153,14 +153,14 @@ int command_del(redis_client_t *client) {
     // update data file, flag entry deleted
     if(!data_delete(data, entry->id, entry->idlength)) {
         zdbd_debug("[-] command: del: deleting data failed\n");
-        redis_hardsend(client, "-Cannot delete key");
+        redis_hardsend(client, "-Cannot delete key (data)");
         return 0;
     }
 
     // mark index entry as deleted
     if(index_entry_delete(index, entry)) {
         zdbd_debug("[-] command: del: index delete flag failed\n");
-        redis_hardsend(client, "-Cannot delete key");
+        redis_hardsend(client, "-Cannot delete key (index)");
         return 0;
     }
 

--- a/zdbd/commands_set.c
+++ b/zdbd/commands_set.c
@@ -165,9 +165,13 @@ static size_t redis_set_handler_sequential(redis_client_t *client, index_entry_t
 
     // checking if we need to update this entry or if data are unchanged
     if(existing && existing->crc == dreq.crc) {
-        zdbd_debug("[+] command: set: existing %08x <> %08x crc match, ignoring\n", existing->crc, dreq.crc);
-        redis_hardsend(client, "$-1");
-        return 0;
+        // it's possible to get same crc for similar data but
+        // with different size, comparing size aswell
+        if(existing->length == valuelength) {
+            zdbd_debug("[+] command: set: existing %08x <> %08x crc match, ignoring\n", existing->crc, dreq.crc);
+            redis_hardsend(client, "$-1");
+            return 0;
+        }
     }
 
     // insert the data into the datafile

--- a/zdbd/zdbd.c
+++ b/zdbd/zdbd.c
@@ -232,7 +232,8 @@ static int proceed(zdb_settings_t *zdb_settings, zdbd_settings_t *zdbd_settings)
     signal_intercept(SIGSEGV, sighandler);
     signal_intercept(SIGINT, sighandler);
     signal_intercept(SIGTERM, sighandler);
-    signal(SIGCHLD, SIG_IGN);
+    // signal(SIGCHLD, SIG_IGN);
+    // FIXME: this will introduce EINTR syscall
 
     zdbd_id_set(zdbd_settings->listen, zdbd_settings->port, zdbd_settings->socket);
 


### PR DESCRIPTION
This branch were intended to be a new version not backward compatible, with filenames changes, but in the meantime some important bug were noticed, which needs to be merged to development.

This pull request introduce the `missing-data` feature, which execute a hook request to get a datafile back if it was removed, useful for offload storage.

In addition, there is an extra check when setting data, if the crc matched, data were not updated, but now the size is checked aswell, otherwise sending 0x00 couple time, at variable size would lead to same crc (we should adopt another method to check, like a checksum, but this break data format and add overhead).

There is a fix on statistics, were namespace storage value were not updated in sequential mode on overwrite.