### PR TITLE
hook: clean zombies process

### DIFF
--- a/libzdb/hook.h
+++ b/libzdb/hook.h
@@ -17,4 +17,7 @@
     pid_t hook_execute(hook_t *hook);
     int hook_execute_wait(hook_t *hook);
     void hook_free(hook_t *hook);
+
+    // need to be called periodicly to cleanup zombies
+    void libzdb_hooks_cleanup();
 #endif

--- a/libzdb/libzdb.h
+++ b/libzdb/libzdb.h
@@ -58,6 +58,8 @@
         uint64_t datadiskread;    // amount of data bytes read on disk (except index loader)
         uint64_t datadiskwrite;   // amount of data bytes written on disk (except namespace creation)
 
+        uint32_t childwait;       // amount of hook child pending
+
     } zdb_stats_t;
 
     typedef struct zdb_settings_t {

--- a/zdbd/redis.c
+++ b/zdbd/redis.c
@@ -1082,6 +1082,9 @@ void redis_idle_process() {
             }
         }
     }
+
+    // discard any pending hook child
+    libzdb_hooks_cleanup();
 }
 
 // handler executed after each command executed

--- a/zdbd/zdbd.c
+++ b/zdbd/zdbd.c
@@ -224,8 +224,6 @@ static int proceed(zdb_settings_t *zdb_settings, zdbd_settings_t *zdbd_settings)
     signal_intercept(SIGSEGV, sighandler);
     signal_intercept(SIGINT, sighandler);
     signal_intercept(SIGTERM, sighandler);
-    // signal(SIGCHLD, SIG_IGN);
-    // FIXME: this will introduce EINTR syscall
 
     zdbd_id_set(zdbd_settings->listen, zdbd_settings->port, zdbd_settings->socket);
 


### PR DESCRIPTION
Hook subsystem was not waiting for child process to finish and previous signal ignore set was disabled because of the wait introduced by missing data event.

This lead to a lof of defunct process if hooks are triggered.

As soon as a new child is spawn, a counter is kept to known how many expected child are still alive and a periodic call to `libzdb_hooks_cleanup` will wait for them and discard them.