### PR TITLE
integrity: improve check and debug logs

### DIFF
--- a/libzdb/libzdb.c
+++ b/libzdb/libzdb.c
@@ -93,7 +93,7 @@ void zdb_tools_hexdump(void *input, size_t length) {
 // global warning and fatal message
 //
 void *zdb_warnp(char *str) {
-    zdb_timelog();
+    zdb_timelog(stderr);
     fprintf(stderr, "[-] %s: %s\n", str, strerror(errno));
     return NULL;
 }
@@ -115,7 +115,7 @@ void zdb_diep(char *str) {
     exit(EXIT_FAILURE);
 }
 
-void zdb_timelog() {
+void zdb_timelog(FILE *fp) {
     struct timeval n, *b;
     double value = 0;
 
@@ -125,7 +125,7 @@ void zdb_timelog() {
     gettimeofday(&n, NULL);
     value = (double)(n.tv_usec - b->tv_usec) / 1000000 + (double)(n.tv_sec - b->tv_sec);
 
-    printf("[% 15.6f]", value);
+    fprintf(fp, "[% 15.6f]", value);
 }
 
 char *zdb_header_date(uint32_t epoch, char *target, size_t length) {

--- a/libzdb/libzdb.h
+++ b/libzdb/libzdb.h
@@ -117,7 +117,7 @@
     void zdb_tools_hexdump(void *input, size_t length);
     char *zdb_header_date(uint32_t epoch, char *target, size_t length);
 
-    void zdb_timelog();
+    void zdb_timelog(FILE *fp);
     void *zdb_warnp(char *str);
     void zdb_diep(char *str);
 
@@ -127,13 +127,13 @@
     #define COLOR_CYAN   "\033[36;1m"
     #define COLOR_RESET  "\033[0m"
 
-    #define zdb_log(fmt, ...)     { zdb_timelog(); printf(fmt, ##__VA_ARGS__); }
-    #define zdb_logerr(fmt, ...)  { zdb_timelog(); fprintf(stderr, fmt, ##__VA_ARGS__); }
+    #define zdb_log(fmt, ...)     { zdb_timelog(stdout); printf(fmt, ##__VA_ARGS__); }
+    #define zdb_logerr(fmt, ...)  { zdb_timelog(stdout); fprintf(stderr, fmt, ##__VA_ARGS__); }
 
-    #define zdb_danger(fmt, ...)  { zdb_timelog(); printf(COLOR_RED    fmt COLOR_RESET "\n", ##__VA_ARGS__); }
-    #define zdb_warning(fmt, ...) { zdb_timelog(); printf(COLOR_YELLOW fmt COLOR_RESET "\n", ##__VA_ARGS__); }
-    #define zdb_success(fmt, ...) { zdb_timelog(); printf(COLOR_GREEN  fmt COLOR_RESET "\n", ##__VA_ARGS__); }
-    #define zdb_notice(fmt, ...)  { zdb_timelog(); printf(COLOR_CYAN   fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdb_danger(fmt, ...)  { zdb_timelog(stdout); printf(COLOR_RED    fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdb_warning(fmt, ...) { zdb_timelog(stdout); printf(COLOR_YELLOW fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdb_success(fmt, ...) { zdb_timelog(stdout); printf(COLOR_GREEN  fmt COLOR_RESET "\n", ##__VA_ARGS__); }
+    #define zdb_notice(fmt, ...)  { zdb_timelog(stdout); printf(COLOR_CYAN   fmt COLOR_RESET "\n", ##__VA_ARGS__); }
 
     #define KB(x)   (x / (1024.0))
     #define MB(x)   (x / (1024 * 1024.0))

--- a/libzdb/libzdb_private.h
+++ b/libzdb/libzdb_private.h
@@ -5,11 +5,11 @@
     void zdb_fulldump(void *data, size_t len);
 
     #ifndef RELEASE
-        #define zdb_verbose(...)  { zdb_timelog(); printf(__VA_ARGS__); }
-        #define zdb_debug(...)    { zdb_timelog(); printf(__VA_ARGS__); }
+        #define zdb_verbose(...)  { zdb_timelog(stdout); printf(__VA_ARGS__); }
+        #define zdb_debug(...)    { zdb_timelog(stdout); printf(__VA_ARGS__); }
         #define zdb_debughex(...) { zdb_hexdump(__VA_ARGS__); }
     #else
-        #define zdb_verbose(...) { if(zdb_rootsettings.verbose) { zdb_timelog(); printf(__VA_ARGS__); } }
+        #define zdb_verbose(...) { if(zdb_rootsettings.verbose) { zdb_timelog(stdout); printf(__VA_ARGS__); } }
         #define zdb_debug(...) ((void)0)
         #define zdb_debughex(...) ((void)0)
     #endif

--- a/tools/integrity-check/integrity-check.c
+++ b/tools/integrity-check/integrity-check.c
@@ -73,10 +73,10 @@ int data_integrity(data_root_t *zdbdata) {
         printf("[+] data entry: %lu, id length: %d\n", entrycount, entry->idlength);
         printf("[+]   expected length: %u, current offset: %" PRId64 "\n", entry->datalength, (int64_t) current);
         printf("[+]   previous offset: %u\n", entry->previous);
-        printf("[+]   expected crc: %08x\n", entry->integrity);
-        printf("[+]   entry key: ");
+        printf("[+]   expected crc   : %08x\n", entry->integrity);
+        printf("[+]   entry flags    : 0x%x\n", entry->flags);
+        printf("[+]   entry key      : ");
         zdb_tools_hexdump(entry->id, entry->idlength);
-        printf("\n");
 
         if(entry->datalength == 0)
             continue;
@@ -94,11 +94,11 @@ int data_integrity(data_root_t *zdbdata) {
             errors += 1;
 
         } else {
-            printf("[+]   data crc: match\n");
+            printf("[+]   data crc       : ok, match\n");
         }
 
         #ifdef SHADUMP
-        printf("[+]   data sha256: ");
+        printf("[+]   data sha256   : ");
         sha256dump(buffer, entry->datalength);
         printf("\n");
         #endif


### PR DESCRIPTION
Improve integrity-check output and fix `stdout/stderr` inconstancy for boot-time text.