### PR TITLE
internal: introduce 'fileid_t' type dedicated to describe file id

### DIFF
--- a/libzdb/api.c
+++ b/libzdb/api.c
@@ -440,11 +440,11 @@ void zdb_index_set_id(index_root_t *root, uint64_t fileid) {
     return index_set_id(root, fileid);
 }
 
-int zdb_index_open_readonly(index_root_t *root, uint16_t fileid) {
+int zdb_index_open_readonly(index_root_t *root, fileid_t fileid) {
     return index_open_readonly(root, fileid);
 }
 
-int zdb_index_open_readwrite(index_root_t *root, uint16_t fileid) {
+int zdb_index_open_readwrite(index_root_t *root, fileid_t fileid) {
     return index_open_readwrite(root, fileid);
 }
 
@@ -469,7 +469,7 @@ uint32_t zdb_checksum_crc32(const uint8_t *bytes, ssize_t length) {
     return data_crc32(bytes, length);
 }
 
-data_root_t *zdb_data_init_lazy(zdb_settings_t *settings, char *datapath, uint16_t dataid) {
+data_root_t *zdb_data_init_lazy(zdb_settings_t *settings, char *datapath, fileid_t dataid) {
     return data_init_lazy(settings, datapath, dataid);
 }
 

--- a/libzdb/api.h
+++ b/libzdb/api.h
@@ -51,8 +51,8 @@
     // index loader
     void zdb_index_set_id(index_root_t *root, uint64_t fileid);
 
-    int zdb_index_open_readonly(index_root_t *root, uint16_t fileid);
-    int zdb_index_open_readwrite(index_root_t *root, uint16_t fileid);
+    int zdb_index_open_readonly(index_root_t *root, fileid_t fileid);
+    int zdb_index_open_readwrite(index_root_t *root, fileid_t fileid);
     void zdb_index_close(index_root_t *zdbindex);
 
     index_root_t *zdb_index_init_lazy(zdb_settings_t *settings, char *indexdir, void *namespace);
@@ -72,7 +72,7 @@
     uint32_t zdb_checksum_crc32(const uint8_t *bytes, ssize_t length);
 
     // data loader
-    data_root_t *zdb_data_init_lazy(zdb_settings_t *settings, char *datapath, uint16_t dataid);
+    data_root_t *zdb_data_init_lazy(zdb_settings_t *settings, char *datapath, fileid_t dataid);
     int zdb_data_open_readonly(data_root_t *root);
 
     data_header_t *zdb_data_descriptor_load(data_root_t *root);

--- a/libzdb/data.h
+++ b/libzdb/data.h
@@ -19,7 +19,7 @@
     typedef struct data_root_t {
         char *datadir;      // root path of the data files
         char *datafile;     // name of current datafile in use
-        uint16_t dataid;    // id of the datafile currently in use
+        fileid_t dataid;    // id of the datafile currently in use
         int datafd;         // file descriptor of the current datafile in use
         int sync;           // flag to force data write sync
         int synctime;       // force to sync data after this timeout (on next write)
@@ -38,7 +38,7 @@
         uint32_t version;  // file version, for eventual upgrade compatibility
         uint64_t created;  // unix timestamp of creation time
         uint64_t opened;   // unix timestamp of last opened time
-        uint16_t fileid;   // current index file id (sync with dataid)
+        fileid_t fileid;   // current index file id (sync with dataid)
 
     } __attribute__((packed)) data_header_t;
 
@@ -110,25 +110,25 @@
 
     } data_request_t;
 
-    data_root_t *data_init(zdb_settings_t *settings, char *datapath, uint16_t dataid);
-    data_root_t *data_init_lazy(zdb_settings_t *settings, char *datapath, uint16_t dataid);
-    int data_open_id_mode(data_root_t *root, uint16_t id, int mode);
+    data_root_t *data_init(zdb_settings_t *settings, char *datapath, fileid_t dataid);
+    data_root_t *data_init_lazy(zdb_settings_t *settings, char *datapath, fileid_t dataid);
+    int data_open_id_mode(data_root_t *root, fileid_t id, int mode);
 
     data_header_t *data_descriptor_load(data_root_t *root);
     data_header_t *data_descriptor_validate(data_header_t *header, data_root_t *root);
 
     void data_destroy(data_root_t *root);
-    size_t data_jump_next(data_root_t *root, uint16_t newid);
+    size_t data_jump_next(data_root_t *root, fileid_t newid);
     void data_emergency(data_root_t *root);
-    uint16_t data_dataid(data_root_t *root);
+    fileid_t data_dataid(data_root_t *root);
     void data_delete_files(data_root_t *root);
 
     uint32_t data_crc32(const uint8_t *bytes, ssize_t length);
 
-    data_payload_t data_get(data_root_t *root, size_t offset, size_t length, uint16_t dataid, uint8_t idlength);
-    int data_check(data_root_t *root, size_t offset, uint16_t dataid);
+    data_payload_t data_get(data_root_t *root, size_t offset, size_t length, fileid_t dataid, uint8_t idlength);
+    int data_check(data_root_t *root, size_t offset, fileid_t dataid);
 
-    // size_t data_match(data_root_t *root, void *id, uint8_t idlength, size_t offset, uint16_t dataid);
+    // size_t data_match(data_root_t *root, void *id, uint8_t idlength, size_t offset, fileid_t dataid);
 
     int data_delete(data_root_t *root, void *id, uint8_t idlength);
 
@@ -136,8 +136,8 @@
     size_t data_insert(data_root_t *root, data_request_t *source);
     size_t data_next_offset(data_root_t *root);
 
-    data_scan_t data_previous_header(data_root_t *root, uint16_t dataid, size_t offset);
-    data_scan_t data_next_header(data_root_t *root, uint16_t dataid, size_t offset);
+    data_scan_t data_previous_header(data_root_t *root, fileid_t dataid, size_t offset);
+    data_scan_t data_next_header(data_root_t *root, fileid_t dataid, size_t offset);
     data_scan_t data_first_header(data_root_t *root);
     data_scan_t data_last_header(data_root_t *root);
 

--- a/libzdb/index.c
+++ b/libzdb/index.c
@@ -159,13 +159,13 @@ static int index_read(int fd, void *buffer, size_t length) {
     return 1;
 }
 
-static char *index_set_id_buffer(char *buffer, char *indexdir, uint16_t indexid) {
+static char *index_set_id_buffer(char *buffer, char *indexdir, fileid_t indexid) {
     sprintf(buffer, "%s/zdb-index-%05u", indexdir, indexid);
     return buffer;
 }
 
 // set global filename based on the index id
-void index_set_id(index_root_t *root, uint16_t fileid) {
+void index_set_id(index_root_t *root, fileid_t fileid) {
     root->indexid = fileid;
     index_set_id_buffer(root->indexfile, root->indexdir, root->indexid);
 
@@ -175,7 +175,7 @@ void index_set_id(index_root_t *root, uint16_t fileid) {
 
 //
 // open index _without_ changing internal fd
-static int index_open_file_mode(index_root_t *root, uint16_t fileid, int mode) {
+static int index_open_file_mode(index_root_t *root, fileid_t fileid, int mode) {
     char filename[512];
     int fd;
 
@@ -190,18 +190,18 @@ static int index_open_file_mode(index_root_t *root, uint16_t fileid, int mode) {
     return fd;
 }
 
-int index_open_file_readonly(index_root_t *root, uint16_t fileid) {
+int index_open_file_readonly(index_root_t *root, fileid_t fileid) {
     return index_open_file_mode(root, fileid, O_RDONLY);
 }
 
-int index_open_file_readwrite(index_root_t *root, uint16_t fileid) {
+int index_open_file_readwrite(index_root_t *root, fileid_t fileid) {
     return index_open_file_mode(root, fileid, O_RDWR);
 }
 
 //
 // open index _with_ internal fd set
 //
-static int index_open_mode(index_root_t *root, uint16_t fileid, int mode) {
+static int index_open_mode(index_root_t *root, fileid_t fileid, int mode) {
     #ifndef RELEASE
     char *roenabled = (mode == O_RDONLY) ? "yes" : "no";
     #endif
@@ -217,15 +217,15 @@ static int index_open_mode(index_root_t *root, uint16_t fileid, int mode) {
     return root->indexfd;
 }
 
-int index_open_readonly(index_root_t *root, uint16_t fileid) {
+int index_open_readonly(index_root_t *root, fileid_t fileid) {
     return index_open_mode(root, fileid, O_RDONLY);
 }
 
-int index_open_readwrite(index_root_t *root, uint16_t fileid) {
+int index_open_readwrite(index_root_t *root, fileid_t fileid) {
     return index_open_mode(root, fileid, O_RDWR);
 }
 
-int index_open_readwrite_oneshot(index_root_t *root, uint16_t fileid) {
+int index_open_readwrite_oneshot(index_root_t *root, fileid_t fileid) {
     int fd;
     char tempfile[2048];
 
@@ -249,7 +249,7 @@ int index_open_readwrite_oneshot(index_root_t *root, uint16_t fileid) {
 // file open, if a new one was opened
 //
 // if the index id could not be opened, -1 is returned
-inline int index_grab_fileid(index_root_t *root, uint16_t fileid) {
+inline int index_grab_fileid(index_root_t *root, fileid_t fileid) {
     int fd = root->indexfd;
 
     if(root->indexid != fileid) {
@@ -263,7 +263,7 @@ inline int index_grab_fileid(index_root_t *root, uint16_t fileid) {
     return fd;
 }
 
-inline void index_release_fileid(index_root_t *root, uint16_t fileid, int fd) {
+inline void index_release_fileid(index_root_t *root, fileid_t fileid, int fd) {
     // if the requested file id (or fd) is not the one
     // currently used by the main structure, we close it
     // since it was temporary
@@ -449,7 +449,7 @@ index_entry_t *index_entry_get(index_root_t *root, unsigned char *id, uint8_t id
 //
 // it is really important in direct mode to use indirection with index
 // to have benefit of compaction etc. and for history support
-index_item_t *index_item_get_disk(index_root_t *root, uint16_t indexid, size_t offset, uint8_t idlength) {
+index_item_t *index_item_get_disk(index_root_t *root, fileid_t indexid, size_t offset, uint8_t idlength) {
     int fd;
     size_t length;
     index_item_t *item;
@@ -601,7 +601,7 @@ int index_entry_delete(index_root_t *root, index_entry_t *entry) {
 
 // serialize into binary object a deserializable
 // object identifier
-index_bkey_t index_item_serialize(index_item_t *item, uint32_t idxoffset, uint16_t idxfileid) {
+index_bkey_t index_item_serialize(index_item_t *item, uint32_t idxoffset, fileid_t idxfileid) {
     zdb_debug("[+] index: item serialize: offset: %" PRIu32 ", fileid: %" PRIu16 "\n", idxoffset, idxfileid);
 
     index_bkey_t key = {
@@ -682,7 +682,7 @@ size_t index_next_offset(index_root_t *root) {
 }
 
 // return current fileid in use
-uint16_t index_indexid(index_root_t *root) {
+fileid_t index_indexid(index_root_t *root) {
     return root->indexid;
 }
 

--- a/libzdb/index_loader.c
+++ b/libzdb/index_loader.c
@@ -239,7 +239,7 @@ static size_t index_load_file(index_root_t *root) {
     }
 
     if(!index_descriptor_validate(&header, root))
-        return 1;
+        exit(EXIT_FAILURE);
 
     zdb_debug("[+] index: running mode: %s\n", zdb_running_mode(header.mode));
 

--- a/libzdb/index_loader.c
+++ b/libzdb/index_loader.c
@@ -83,7 +83,7 @@ static void index_dump_statistics(index_root_t *root) {
 // initialize an index file
 // this basicly create the header and write it
 //
-index_header_t index_initialize(int fd, uint16_t indexid, index_root_t *root) {
+index_header_t index_initialize(int fd, fileid_t indexid, index_root_t *root) {
     index_header_t header;
 
     memcpy(header.magic, "IDX0", 4);

--- a/libzdb/index_loader.c
+++ b/libzdb/index_loader.c
@@ -372,7 +372,7 @@ static size_t index_load_file(index_root_t *root) {
 
 // returns the amount of index files available (if any)
 uint64_t index_availity_check(index_root_t *root) {
-    uint64_t maxfiles = (1 << (sizeof(((index_entry_t *) 0)->dataid) * 8));
+    uint64_t maxfiles = (1ULL << (sizeof(((index_entry_t *) 0)->dataid) * 8)) - 1;
     uint64_t fileid;
 
     for(fileid = 0; fileid < maxfiles; fileid++) {

--- a/libzdb/index_loader.h
+++ b/libzdb/index_loader.h
@@ -2,7 +2,7 @@
     #define __ZDB_INDEX_LOADER_H
 
     // initialize index header file
-    index_header_t index_initialize(int fd, uint16_t indexid, index_root_t *root);
+    index_header_t index_initialize(int fd, fileid_t indexid, index_root_t *root);
 
     // initialize the whole index system
     index_root_t *index_init(zdb_settings_t *settings, char *indexdir, void *namespace, index_branch_t **branches);

--- a/libzdb/index_scan.c
+++ b/libzdb/index_scan.c
@@ -170,7 +170,7 @@ static index_scan_t index_previous_header_real(index_scan_t scan) {
     return scan;
 }
 
-index_scan_t index_previous_header(index_root_t *root, uint16_t fileid, size_t offset) {
+index_scan_t index_previous_header(index_root_t *root, fileid_t fileid, size_t offset) {
     index_scan_t scan = {
         .fd = 0,
         .fileid = fileid,
@@ -286,7 +286,7 @@ static index_scan_t index_next_header_real(index_scan_t scan) {
     return scan;
 }
 
-index_scan_t index_next_header(index_root_t *root, uint16_t fileid, size_t offset) {
+index_scan_t index_next_header(index_root_t *root, fileid_t fileid, size_t offset) {
     index_scan_t scan = {
         .fd = 0,
         .fileid = fileid,

--- a/libzdb/index_scan.h
+++ b/libzdb/index_scan.h
@@ -22,12 +22,12 @@
                           // target will be updated if the offset is in another file
         index_item_t *header;        // target header, set when found
         index_scan_status_t status;  // status code
-        uint16_t fileid;             // index file id
+        fileid_t fileid;             // index file id
 
     } index_scan_t;
 
-    index_scan_t index_previous_header(index_root_t *root, uint16_t fileid, size_t offset);
-    index_scan_t index_next_header(index_root_t *root, uint16_t fileid, size_t offset);
+    index_scan_t index_previous_header(index_root_t *root, fileid_t fileid, size_t offset);
+    index_scan_t index_next_header(index_root_t *root, fileid_t fileid, size_t offset);
     index_scan_t index_first_header(index_root_t *root);
     index_scan_t index_last_header(index_root_t *root);
 #endif

--- a/libzdb/index_seq.c
+++ b/libzdb/index_seq.c
@@ -9,8 +9,8 @@
 // perform a binary search on the seqmap to get
 // the fileid back based on the index mapped with fileid
 static index_seqmap_t *index_seqmap_from_seq(index_seqid_t *seqid, uint32_t id) {
-    int lower = 0;
-    int higher = seqid->length;
+    uint32_t lower = 0;
+    uint32_t higher = seqid->length;
 
     // binary search
     while(lower < higher) {
@@ -47,7 +47,7 @@ index_seqmap_t *index_fileid_from_seq(index_root_t *root, uint32_t seqid) {
     return seqmap;
 }
 
-void index_seqid_push(index_root_t *root, uint32_t id, uint16_t indexid) {
+void index_seqid_push(index_root_t *root, uint32_t id, fileid_t indexid) {
     zdb_debug("[+] index seq: mapping id %u to file %u\n", id, indexid);
 
     if(root->seqid->length + 1 == root->seqid->allocated) {
@@ -82,7 +82,7 @@ size_t index_seq_offset(uint32_t relative) {
 }
 
 void index_seqid_dump(index_root_t *root) {
-    for(uint16_t i = 0; i < root->seqid->length; i++) {
+    for(fileid_t i = 0; i < root->seqid->length; i++) {
         index_seqmap_t *item = &root->seqid->seqmap[i];
         zdb_log("[+] index seq: seqid %d -> file %d\n", item->seqid, item->fileid);
     }

--- a/libzdb/index_seq.h
+++ b/libzdb/index_seq.h
@@ -2,7 +2,7 @@
     #define __ZDB_INDEX_SEQ_H
 
     index_seqmap_t *index_fileid_from_seq(index_root_t *root, uint32_t seqid);
-    void index_seqid_push(index_root_t *root, uint32_t id, uint16_t indexid);
+    void index_seqid_push(index_root_t *root, uint32_t id, fileid_t indexid);
     size_t index_seq_offset(uint32_t relative);
 
     void index_seqid_dump(index_root_t *root);

--- a/libzdb/libzdb.h
+++ b/libzdb/libzdb.h
@@ -115,6 +115,11 @@
 
     } zdb_settings_t;
 
+    // fileid_t represent internal size of fileid type, which was
+    // historically hardcoded to uint16_t everywhere, but make code less
+    // easy to update if this size need to change
+    typedef uint16_t fileid_t;
+
     void zdb_tools_fulldump(void *_data, size_t len);
     void zdb_tools_hexdump(void *input, size_t length);
     char *zdb_header_date(uint32_t epoch, char *target, size_t length);

--- a/tools/compaction/compaction.c
+++ b/tools/compaction/compaction.c
@@ -81,7 +81,7 @@ int compaction_copy(int fdin, int fdout, size_t size) {
     return 0;
 }
 
-index_entry_t *compaction_handle_entry(index_root_t *index, data_entry_header_t *entry, char *id, compaction_t *compaction, uint16_t fileid) {
+index_entry_t *compaction_handle_entry(index_root_t *index, data_entry_header_t *entry, char *id, compaction_t *compaction, fileid_t fileid) {
     datamap_t *datamap = compaction->filesmap[fileid];
     index_entry_t *idxentry = NULL;
 
@@ -118,7 +118,7 @@ index_entry_t *compaction_handle_entry(index_root_t *index, data_entry_header_t 
     return idxentry;
 }
 
-size_t compaction_data_load(int fd, index_root_t *index, compaction_t *compaction, uint16_t fileid) {
+size_t compaction_data_load(int fd, index_root_t *index, compaction_t *compaction, fileid_t fileid) {
     datamap_t *datamap = compaction->filesmap[fileid];
     data_header_t header;
 
@@ -186,7 +186,7 @@ size_t compaction_data_load(int fd, index_root_t *index, compaction_t *compactio
     return datamap->length;
 }
 
-size_t compaction_data_convert(int fd, int outfd, compaction_t *compaction, uint16_t fileid) {
+size_t compaction_data_convert(int fd, int outfd, compaction_t *compaction, fileid_t fileid) {
     datamap_t *datamap = compaction->filesmap[fileid];
 
     // copying header

--- a/tools/compaction/compaction.h
+++ b/tools/compaction/compaction.h
@@ -12,7 +12,7 @@
     typedef struct datamap_t {
         size_t length;
         size_t allocated;
-        uint16_t fileid;
+        fileid_t fileid;
         datamap_entry_t *entries;
 
     } datamap_t;

--- a/tools/index-dump/index-dump.c
+++ b/tools/index-dump/index-dump.c
@@ -9,7 +9,7 @@ int index_dump_files(index_root_t *zdbindex, uint64_t maxfile) {
     char datestr[64];
     size_t totalentries = 0;
 
-    for(uint16_t fileid = 0; fileid < maxfile; fileid += 1) {
+    for(fileid_t fileid = 0; fileid < maxfile; fileid += 1) {
         //
         // loading index file
         //

--- a/tools/index-rebuild/index-rebuild.c
+++ b/tools/index-rebuild/index-rebuild.c
@@ -18,7 +18,7 @@ static struct option long_options[] = {
     {0, 0, 0, 0}
 };
 
-int index_data_jump_to(uint16_t fileid, index_root_t *zdbindex, data_root_t *zdbdata) {
+int index_data_jump_to(fileid_t fileid, index_root_t *zdbindex, data_root_t *zdbdata) {
     data_header_t *header;
     char datestr[64];
 
@@ -131,7 +131,7 @@ ssize_t index_rebuild_pass(index_root_t *zdbindex, data_root_t *zdbdata, time_t 
 
 
 int index_rebuild(index_root_t *zdbindex, data_root_t *zdbdata, time_t timestamp) {
-    uint16_t fileid = 0;
+    fileid_t fileid = 0;
     ssize_t entries = 0;
     size_t entrycount = 0;
 

--- a/tools/integrity-check/integrity-check.c
+++ b/tools/integrity-check/integrity-check.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[]) {
         exit(EXIT_FAILURE);
     }
 
-    uint16_t dataid = atoi(datafile + 9);
+    fileid_t dataid = atoi(datafile + 9);
 
     printf("[+] datafile path: %s\n", filedir);
     printf("[+] datafile name: %s\n", datafile);

--- a/tools/quick-compaction/quick-compact.c
+++ b/tools/quick-compaction/quick-compact.c
@@ -47,7 +47,7 @@ typedef struct session_t {
 
 } session_t;
 
-int index_data_jump_to(uint16_t fileid, index_root_t *zdbindex, data_root_t *zdbdata) {
+int index_data_jump_to(fileid_t fileid, index_root_t *zdbindex, data_root_t *zdbdata) {
     data_header_t *header;
     char datestr[64];
 
@@ -129,7 +129,7 @@ static int quick_initialize(instance_t *input, instance_t *output) {
     return 0;
 }
 
-size_t quick_compact_pass(instance_t *input, instance_t *output, uint16_t fileid, session_t *session) {
+size_t quick_compact_pass(instance_t *input, instance_t *output, fileid_t fileid, session_t *session) {
     size_t entrycount = 0;
     int indexfd, datafd;
     char buffer[2048];
@@ -294,7 +294,7 @@ size_t quick_compact_pass(instance_t *input, instance_t *output, uint16_t fileid
 }
 
 int quick_compaction(instance_t *input, instance_t *output) {
-    uint16_t fileid = 0;
+    fileid_t fileid = 0;
     size_t entrycount = 0;
     session_t session = {
         .dataprev = 0,

--- a/zdbd/commands_get.c
+++ b/zdbd/commands_get.c
@@ -6,8 +6,8 @@
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <inttypes.h>
-#include "index.h"
 #include "libzdb.h"
+#include "index.h"
 #include "zdbd.h"
 #include "redis.h"
 #include "commands.h"

--- a/zdbd/commands_scan.h
+++ b/zdbd/commands_scan.h
@@ -7,8 +7,8 @@
     int command_kscan(redis_client_t *client);
 
     typedef struct scan_info_t {
-        uint16_t dataid;
-        uint16_t idxid;
+        fileid_t dataid;
+        fileid_t idxid;
         size_t idxoffset;
 
     } scan_info_t;

--- a/zdbd/zdbd.c
+++ b/zdbd/zdbd.c
@@ -462,7 +462,7 @@ int main(int argc, char *argv[]) {
 
     // max files is limited by type length of dataid, which is uint16 by default
     // taking field size in bytes, multiplied by 8 for bits
-    size_t maxfiles = 1 << sizeof(((data_root_t *) 0)->dataid) * 8;
+    size_t maxfiles = (1ULL << (sizeof(((data_root_t *) 0)->dataid) * 8)) - 1;
 
     // max database size is maximum datafile size multiplied by amount of files
     uint64_t maxsize = maxfiles * zdb_settings->datasize;


### PR DESCRIPTION
Previously, `files id` (`index id` and `data id`) were hardcoded to `uint16_t` everywhere.
This pull request introduce a new type called `fileid_t` which unify this type and make it generic everywhere in the code.

The type didn't changed, it's still `uint16_t` but customized and easier to change later.
This make transition to `v2` easier.

Related to #93 