### PR TITLE
core: increase sequential keys to 64 bits and more

### DIFF
--- a/libzdb/api.c
+++ b/libzdb/api.c
@@ -182,8 +182,8 @@ static zdb_api_t *api_set_handler_sequential(namespace_t *ns, void *key, size_t 
     // create some easier accessor
     // grab the next id, this may be replaced
     // by user input if the key exists
-    uint32_t id = index_next_id(ns->index);
-    uint8_t idlength = sizeof(uint32_t);
+    seqid_t id = index_next_id(ns->index);
+    uint8_t idlength = sizeof(seqid_t);
 
     // setting key to existing if we do an update
     if(existing)

--- a/libzdb/data.c
+++ b/libzdb/data.c
@@ -131,7 +131,7 @@ int data_open_id_mode(data_root_t *root, fileid_t id, int mode) {
     int retried = 0;
     int fd;
 
-    sprintf(temp, "%s/zdb-data-%05u", root->datadir, id);
+    sprintf(temp, "%s/d%u", root->datadir, id);
     zdb_debug("[+] data: opening file: %s (ro: %s)\n", temp, (mode & O_RDONLY) ? "yes" : "no");
 
     while((fd = open(temp, mode, 0600)) < 0) {
@@ -269,7 +269,7 @@ void data_initialize(char *filename, data_root_t *root) {
 
 // simply set globally the current filename based on it's id
 static void data_set_id(data_root_t *root) {
-    sprintf(root->datafile, "%s/zdb-data-%05u", root->datadir, root->dataid);
+    sprintf(root->datafile, "%s/d%u", root->datadir, root->dataid);
 }
 
 static void data_open_final(data_root_t *root) {

--- a/libzdb/index.c
+++ b/libzdb/index.c
@@ -160,7 +160,7 @@ static int index_read(int fd, void *buffer, size_t length) {
 }
 
 static char *index_set_id_buffer(char *buffer, char *indexdir, fileid_t indexid) {
-    sprintf(buffer, "%s/zdb-index-%05u", indexdir, indexid);
+    sprintf(buffer, "%s/i%u", indexdir, indexid);
     return buffer;
 }
 
@@ -179,7 +179,7 @@ static int index_open_file_mode(index_root_t *root, fileid_t fileid, int mode) {
     char filename[512];
     int fd;
 
-    sprintf(filename, "%s/zdb-index-%05u", root->indexdir, fileid);
+    sprintf(filename, "%s/i%u", root->indexdir, fileid);
     zdb_debug("[+] index: opening file: %s (ro: %s)\n", filename, (mode & O_RDONLY) ? "yes" : "no");
 
     if((fd = open(filename, mode)) < 0) {

--- a/libzdb/index.c
+++ b/libzdb/index.c
@@ -10,7 +10,6 @@
 #include <time.h>
 #include <limits.h>
 #include <x86intrin.h>
-#include <endian.h>
 #include "libzdb.h"
 #include "libzdb_private.h"
 
@@ -397,12 +396,6 @@ uint64_t index_next_id(index_root_t *root) {
     // this is used on sequential-id
     // it gives the next id
     return root->nextentry;
-}
-
-seqid_t index_next_seqid(index_root_t *root) {
-    // this is used on sequential-id
-    // it gives the next id
-    return htobe64(root->nextentry);
 }
 
 uint32_t index_next_objectid(index_root_t *root) {

--- a/libzdb/index.c
+++ b/libzdb/index.c
@@ -10,6 +10,7 @@
 #include <time.h>
 #include <limits.h>
 #include <x86intrin.h>
+#include <endian.h>
 #include "libzdb.h"
 #include "libzdb_private.h"
 
@@ -394,6 +395,12 @@ uint64_t index_next_id(index_root_t *root) {
     // this is used on sequential-id
     // it gives the next id
     return root->nextentry;
+}
+
+seqid_t index_next_seqid(index_root_t *root) {
+    // this is used on sequential-id
+    // it gives the next id
+    return htobe64(root->nextentry);
 }
 
 uint32_t index_next_objectid(index_root_t *root) {

--- a/libzdb/index.h
+++ b/libzdb/index.h
@@ -135,9 +135,12 @@
 
     } index_status_t;
 
+    // seqid_t represent a sequential id type
+    typedef uint64_t seqid_t;
+
     // index sequential id mapping
     typedef struct index_seqmap_t {
-        uint32_t seqid;
+        seqid_t seqid;
         fileid_t fileid;
 
     } index_seqmap_t;
@@ -214,7 +217,7 @@
     // the same length, we can compute offset like this
     typedef struct index_dkey_t {
         fileid_t indexid;
-        uint32_t objectid;
+        seqid_t objectid;
 
     } __attribute__((packed)) index_dkey_t;
 
@@ -262,6 +265,7 @@
     int index_emergency(index_root_t *root);
 
     uint64_t index_next_id(index_root_t *root);
+    seqid_t index_next_seqid(index_root_t *root);
     uint32_t index_next_objectid(index_root_t *root);
 
     index_entry_t *index_entry_get(index_root_t *root, unsigned char *id, uint8_t length);

--- a/libzdb/index.h
+++ b/libzdb/index.h
@@ -266,7 +266,6 @@
     int index_emergency(index_root_t *root);
 
     uint64_t index_next_id(index_root_t *root);
-    seqid_t index_next_seqid(index_root_t *root);
     uint32_t index_next_objectid(index_root_t *root);
 
     index_entry_t *index_entry_get(index_root_t *root, unsigned char *id, uint8_t length);

--- a/libzdb/index_get.c
+++ b/libzdb/index_get.c
@@ -14,14 +14,15 @@ static index_entry_t *index_get_handler_memkey(index_root_t *index, void *id, ui
 }
 
 static index_entry_t *index_get_handler_sequential(index_root_t *index, void *id, uint8_t idlength) {
-    if(idlength != sizeof(uint32_t)) {
-        zdb_debug("[-] index: sequential get: invalid key length (%u <> %ld)\n", idlength, sizeof(uint32_t));
+    if(idlength != sizeof(seqid_t)) {
+        zdb_debug("[-] index: sequential get: invalid key length (%u <> %ld)\n", idlength, sizeof(seqid_t));
         return NULL;
     }
 
     // converting key into binary format
-    uint32_t key;
-    memcpy(&key, id, sizeof(uint32_t));
+    seqid_t key;
+    memcpy(&key, id, sizeof(seqid_t));
+    key = be64toh(key);
 
     // resolving key into file id
     index_seqmap_t *seqmap = index_fileid_from_seq(index, key);

--- a/libzdb/index_get.c
+++ b/libzdb/index_get.c
@@ -22,7 +22,7 @@ static index_entry_t *index_get_handler_sequential(index_root_t *index, void *id
     // converting key into binary format
     seqid_t key;
     memcpy(&key, id, sizeof(seqid_t));
-    key = be64toh(key);
+    // key = be64toh(key);
 
     // resolving key into file id
     index_seqmap_t *seqmap = index_fileid_from_seq(index, key);
@@ -34,7 +34,7 @@ static index_entry_t *index_get_handler_sequential(index_root_t *index, void *id
     // reading index on disk
     index_item_t *item;
 
-    if(!(item = index_item_get_disk(index, seqmap->fileid, offset, sizeof(uint32_t))))
+    if(!(item = index_item_get_disk(index, seqmap->fileid, offset, sizeof(seqid_t))))
         return NULL;
 
     memcpy(index_reusable_entry->id, item->id, item->idlength);

--- a/libzdb/index_loader.c
+++ b/libzdb/index_loader.c
@@ -400,7 +400,7 @@ void index_internal_load(index_root_t *root) {
     // check for old database file
     char legacy[256];
     sprintf(legacy, "%s/zdb-index-00000", root->indexdir);
-    if(zdb_file_exists(legacy)) {
+    if(zdb_file_exists(legacy) == ZDB_FILE_EXISTS) {
         zdb_danger("[-] index: =================================");
         zdb_danger("[-] index: unsupported database detected");
         zdb_danger("[-] index: =================================");

--- a/libzdb/index_loader.c
+++ b/libzdb/index_loader.c
@@ -396,6 +396,23 @@ void index_internal_load(index_root_t *root) {
     uint64_t maxfile = index_availity_check(root);
     uint64_t fileid;
 
+    // legacy check:
+    // check for old database file
+    char legacy[256];
+    sprintf(legacy, "%s/zdb-index-00000", root->indexdir);
+    if(zdb_file_exists(legacy)) {
+        zdb_danger("[-] index: =================================");
+        zdb_danger("[-] index: unsupported database detected");
+        zdb_danger("[-] index: =================================");
+        zdb_danger("[-] index: ");
+        zdb_danger("[-] index: index directory seems to contains old database");
+        zdb_danger("[-] index: files like 'zdb-index-00000' which is not supported");
+        zdb_danger("[-] index: ");
+        zdb_danger("[-] index: retro-compability is not supported");
+
+        exit(EXIT_FAILURE);
+    }
+
     if(maxfile > 0) {
         // opening all index files one by one
         for(fileid = 0; fileid < maxfile; fileid++) {

--- a/libzdb/index_seq.c
+++ b/libzdb/index_seq.c
@@ -8,13 +8,13 @@
 
 // perform a binary search on the seqmap to get
 // the fileid back based on the index mapped with fileid
-static index_seqmap_t *index_seqmap_from_seq(index_seqid_t *seqid, uint32_t id) {
-    uint32_t lower = 0;
-    uint32_t higher = seqid->length;
+static index_seqmap_t *index_seqmap_from_seq(index_seqid_t *seqid, seqid_t id) {
+    seqid_t lower = 0;
+    seqid_t higher = seqid->length;
 
     // binary search
     while(lower < higher) {
-        int mid = (lower + higher) / 2;
+        seqid_t mid = (lower + higher) / 2;
 
         // exact match
         if(id == seqid->seqmap[mid].seqid)
@@ -40,15 +40,15 @@ static index_seqmap_t *index_seqmap_from_seq(index_seqid_t *seqid, uint32_t id) 
     return &seqid->seqmap[lower];
 }
 
-index_seqmap_t *index_fileid_from_seq(index_root_t *root, uint32_t seqid) {
+index_seqmap_t *index_fileid_from_seq(index_root_t *root, seqid_t seqid) {
     index_seqmap_t *seqmap = index_seqmap_from_seq(root->seqid, seqid);
-    zdb_debug("[+] index: seqmap: resolving %d -> file %u\n", seqid, seqmap->fileid);
+    zdb_debug("[+] index: seqmap: resolving %lu -> file %u\n", seqid, seqmap->fileid);
 
     return seqmap;
 }
 
-void index_seqid_push(index_root_t *root, uint32_t id, fileid_t indexid) {
-    zdb_debug("[+] index seq: mapping id %u to file %u\n", id, indexid);
+void index_seqid_push(index_root_t *root, seqid_t id, fileid_t indexid) {
+    zdb_debug("[+] index seq: mapping id %lu to file %u\n", id, indexid);
 
     if(root->seqid->length + 1 == root->seqid->allocated) {
         // growing up the vector
@@ -64,7 +64,7 @@ void index_seqid_push(index_root_t *root, uint32_t id, fileid_t indexid) {
     root->seqid->length += 1;
 }
 
-size_t index_seq_offset(uint32_t relative) {
+size_t index_seq_offset(seqid_t relative) {
     // skip index header
     size_t offset = sizeof(index_header_t);
 
@@ -76,7 +76,7 @@ size_t index_seq_offset(uint32_t relative) {
     // always fixed-length
     //
     //                       each entry            fixed-key-length
-    offset += (relative * (sizeof(index_item_t) + sizeof(uint32_t)));
+    offset += (relative * (sizeof(index_item_t) + sizeof(seqid_t)));
 
     return offset;
 }
@@ -84,8 +84,7 @@ size_t index_seq_offset(uint32_t relative) {
 void index_seqid_dump(index_root_t *root) {
     for(fileid_t i = 0; i < root->seqid->length; i++) {
         index_seqmap_t *item = &root->seqid->seqmap[i];
-        zdb_log("[+] index seq: seqid %d -> file %d\n", item->seqid, item->fileid);
+        zdb_log("[+] index seq: seqid %lu -> file %u\n", item->seqid, item->fileid);
     }
 }
-
 

--- a/libzdb/index_seq.h
+++ b/libzdb/index_seq.h
@@ -1,9 +1,9 @@
 #ifndef __ZDB_INDEX_SEQ_H
     #define __ZDB_INDEX_SEQ_H
 
-    index_seqmap_t *index_fileid_from_seq(index_root_t *root, uint32_t seqid);
-    void index_seqid_push(index_root_t *root, uint32_t id, fileid_t indexid);
-    size_t index_seq_offset(uint32_t relative);
+    index_seqmap_t *index_fileid_from_seq(index_root_t *root, seqid_t seqid);
+    void index_seqid_push(index_root_t *root, seqid_t id, fileid_t indexid);
+    size_t index_seq_offset(seqid_t relative);
 
     void index_seqid_dump(index_root_t *root);
 #endif

--- a/libzdb/index_set.c
+++ b/libzdb/index_set.c
@@ -61,14 +61,14 @@ int index_seq_overwrite(index_root_t *root, index_set_t *set) {
     size_t entrylength = sizeof(index_item_t) + entry->idlength;
 
     // converting key into binary format
-    uint32_t key;
-    memcpy(&key, set->id, sizeof(uint32_t));
+    seqid_t key;
+    memcpy(&key, set->id, sizeof(seqid_t));
 
     // resolving key into file id
     index_seqmap_t *seqmap = index_fileid_from_seq(root, key);
 
     // resolving relative offset
-    uint32_t relative = key - seqmap->seqid;
+    uint64_t relative = key - seqmap->seqid;
     uint32_t offset = index_seq_offset(relative);
 
     // (re-)open the expected index file, in read-write mode

--- a/libzdb/libzdb.h
+++ b/libzdb/libzdb.h
@@ -27,7 +27,7 @@
     // if some updates are made, upgrade tools should be written
     // to update the existing databases
     #define ZDB_DATAFILE_VERSION    3
-    #define ZDB_IDXFILE_VERSION     3
+    #define ZDB_IDXFILE_VERSION     4
 
     // define here version of 0-db itself
     // version is made as following:

--- a/libzdb/namespace.c
+++ b/libzdb/namespace.c
@@ -68,15 +68,14 @@ namespace_t *namespace_get(char *name) {
 
 // FIXME: no error handled externally
 void namespace_descriptor_update(namespace_t *namespace, int fd) {
-    ns_header_legacy_t header;
-    ns_header_extended_t extended;
+    ns_header_t header;
 
     zdb_debug("[+] namespaces: updating header\n");
 
-    // legacy
+    header.version = NAMESPACE_CURRENT_VERSION;
     header.namelength = strlen(namespace->name);
     header.passlength = namespace->password ? strlen(namespace->password) : 0;
-    header.maxsize = 0; // not used anymore
+    header.maxsize = namespace->maxsize;
     header.flags = NS_FLAGS_EXTENDED;
 
     if(namespace->public)
@@ -85,7 +84,7 @@ void namespace_descriptor_update(namespace_t *namespace, int fd) {
     if(namespace->worm)
         header.flags |= NS_FLAGS_WORM;
 
-    if(write(fd, &header, sizeof(ns_header_legacy_t)) != sizeof(ns_header_legacy_t))
+    if(write(fd, &header, sizeof(ns_header_t)) != sizeof(ns_header_t))
         zdb_warnp("namespace legacy header write");
 
     if(write(fd, namespace->name, header.namelength) != (ssize_t) header.namelength)
@@ -96,52 +95,7 @@ void namespace_descriptor_update(namespace_t *namespace, int fd) {
             zdb_warnp("namespace header password write");
     }
 
-    // extended
-    extended.version = namespace->version;
-    extended.maxsize = namespace->maxsize;
-
-    if(write(fd, &extended, sizeof(ns_header_extended_t)) != sizeof(ns_header_extended_t))
-        zdb_warnp("namespace extended header write");
-
     // ensure metadata are written
-    fsync(fd);
-}
-
-// upgrade a descriptor to support extended fields
-void namespace_descriptor_upgrade(ns_header_legacy_t *header, int fd) {
-    ns_header_extended_t extended;
-
-    zdb_debug("[+] namespaces: upgrading header (extending)\n");
-
-    // enable extended flag
-    header->flags |= NS_FLAGS_EXTENDED;
-
-    // initialize extended settings
-    extended.version = NAMESPACE_CURRENT_VERSION;
-    extended.maxsize = 0;
-
-    // port old maxsize to new extended header
-    // only if the value is less than 2 GB, which was
-    // the previous hard limit
-    if(header->maxsize < (((uint32_t) 1 << 31)))
-        extended.maxsize = header->maxsize;
-
-    // rollback to the beginin of the file
-    lseek(fd, 0, SEEK_SET);
-
-    // rewriting legacy struct with extended flag enabled
-    if(write(fd, header, sizeof(ns_header_legacy_t)) != sizeof(ns_header_legacy_t))
-        zdb_warnp("namespace legacy header write");
-
-    // jump to extended position
-    ssize_t skip = sizeof(ns_header_legacy_t) + header->namelength + header->passlength;
-    lseek(fd, skip, SEEK_SET);
-
-    // writing extended struct
-    if(write(fd, &extended, sizeof(ns_header_extended_t)) != sizeof(ns_header_extended_t))
-        zdb_warnp("namespace extended header write");
-
-    // ensure metadata is written
     fsync(fd);
 }
 
@@ -163,42 +117,28 @@ static int namespace_descriptor_open(namespace_t *namespace) {
 // a namespace descriptor is a binary file containing the namespace
 // specification such as password, maxsize, etc. (see header)
 static int namespace_descriptor_load(namespace_t *namespace) {
-    ns_header_legacy_t header;
-    ns_header_extended_t extended;
+    ns_header_t header;
     int fd;
 
     if((fd = namespace_descriptor_open(namespace)) < 0)
         return fd;
 
-    if(read(fd, &header, sizeof(ns_header_legacy_t)) != sizeof(ns_header_legacy_t)) {
+    if(read(fd, &header, sizeof(ns_header_t)) != sizeof(ns_header_t)) {
         // probably new file, let's write initial namespace information
         namespace_descriptor_update(namespace, fd);
         close(fd);
         return 0;
     }
 
-    // retro-compatibility with old format
-    if((header.flags & NS_FLAGS_EXTENDED) == 0) {
-        zdb_warning("[-] WARNING: updating namespace header");
-        zdb_warning("[-] WARNING: descriptor was created using old 0-db version");
-        zdb_warning("[-] WARNING: updates are retro-compatible");
-
-        namespace_descriptor_upgrade(&header, fd);
+    if(header.version != NAMESPACE_CURRENT_VERSION) {
+        zdb_danger("[-] %s: unsupported version detected", namespace->name);
+        return -1;
     }
 
-    // extended is set, reading extended struct
-    ssize_t skip = sizeof(ns_header_legacy_t) + header.namelength + header.passlength;
-    lseek(fd, skip, SEEK_SET);
-
-    if(read(fd, &extended, sizeof(ns_header_extended_t)) != sizeof(ns_header_extended_t)) {
-        zdb_warnp("namespace extended read");
-        return 0;
-    }
-
-    namespace->maxsize = extended.maxsize;
+    namespace->maxsize = header.maxsize;
     namespace->public = (header.flags & NS_FLAGS_PUBLIC);
     namespace->worm = (header.flags & NS_FLAGS_WORM);
-    namespace->version = extended.version;
+    namespace->version = header.version;
 
     if(header.passlength) {
         if(!(namespace->password = calloc(sizeof(char), header.passlength + 1))) {
@@ -207,7 +147,7 @@ static int namespace_descriptor_load(namespace_t *namespace) {
         }
 
         // skip the namespace name, jump to password
-        lseek(fd, skip - header.passlength, SEEK_SET);
+        lseek(fd, sizeof(ns_header_t) + header.namelength, SEEK_SET);
 
         if(read(fd, namespace->password, header.passlength) != (ssize_t) header.passlength)
             zdb_warnp("namespace password read");

--- a/libzdb/namespace.h
+++ b/libzdb/namespace.h
@@ -14,7 +14,7 @@
     typedef enum ns_flags_t {
         NS_FLAGS_PUBLIC = 1,   // public read-only namespace
         NS_FLAGS_WORM = 2,     // worm mode enabled or not
-        NS_FLAGS_EXTENDED = 4, // extended header is present
+        NS_FLAGS_EXTENDED = 4, // extended header is present (legacy, mandatory)
 
     } ns_flags_t;
 
@@ -22,35 +22,19 @@
         NS_LOCK_UNLOCKED = 0,
         NS_LOCK_READ_ONLY = 1,
         NS_LOCK_READ_WRITE = 2,
+
     } ns_lock_t;
 
-    // ns_header_legacy_t contains the header of a specific namespace for previous 0-db
-    // version, this header will be the only content of the namespace descriptor file
-    typedef struct ns_header_legacy_t {
+    // ns_header_t contains the header of a specific namespace
+    // this header will be the only content of the namespace descriptor file
+    typedef struct ns_header_t {
+        uint32_t version;      // keep track of this version
         uint8_t namelength;    // length of the namespace name
         uint8_t passlength;    // length of the password
-        uint32_t maxsize;      // old maximum size (ignored, see extended)
+        uint64_t maxsize;      // maximum namespace size (if defined)
         uint8_t flags;         // some flags (see define above)
 
-        // this header won't never change, this is the first version
-        // deployed, to keep retro-compatibility with old database
-        // we keep the same prefix
-        //
-        // new version contains more fields and contains a version
-        // identifier used to keep track of update
-        //
-        // the flag NS_FLAGS_EXTENDED is set when the header used is
-        // any new version, which means you can still load old version
-        // and new version will still works on previous version
-
-    } __attribute__((packed)) ns_header_legacy_t;
-
-    typedef struct ns_header_extended_t {
-        uint32_t version;  // keep track of this version
-        uint64_t maxsize;  // real maxsize encoded on 64 bits (no 4 GB limit)
-
-    } __attribute__((packed)) ns_header_extended_t;
-
+    } __attribute__((packed)) ns_header_t;
 
     typedef struct namespace_t {
         char *name;            // namespace string-name

--- a/zdbd/commands_namespace.c
+++ b/zdbd/commands_namespace.c
@@ -291,7 +291,7 @@ int command_nsinfo(redis_client_t *client) {
         return 1;
 
     // value is hard-capped to 32 bits, even if internal uses 64 bits
-    uint32_t nextid = (uint32_t) zdb_index_next_id(namespace->index);
+    uint64_t nextid = zdb_index_next_id(namespace->index);
 
     // compute free space available
     size_t available = namespace->maxsize - namespace->index->stats.datasize;
@@ -309,7 +309,7 @@ int command_nsinfo(redis_client_t *client) {
     len += sprintf(info + len, "data_limits_bytes: %lu\n", namespace->maxsize);
     len += sprintf(info + len, "index_size_bytes: %lu\n", namespace->index->stats.size);
     len += sprintf(info + len, "index_size_kb: %.2f\n", KB(namespace->index->stats.size));
-    len += sprintf(info + len, "next_internal_id: 0x%08x\n", bswap_32(nextid));
+    len += sprintf(info + len, "next_internal_id: 0x%08lx\n", bswap_64(nextid));
     len += sprintf(info + len, "mode: %s\n", index_modename(namespace->index));
     len += sprintf(info + len, "stats_index_io_errors: %lu\n", namespace->index->stats.errors);
     len += sprintf(info + len, "stats_index_io_error_last: %ld\n", namespace->index->stats.lasterr);

--- a/zdbd/commands_set.c
+++ b/zdbd/commands_set.c
@@ -138,8 +138,8 @@ static size_t redis_set_handler_sequential(redis_client_t *client, index_entry_t
     // create some easier accessors
     // grab the next id, this may be replaced
     // by user input if the key exists
-    uint32_t id = index_next_id(index);
-    uint8_t idlength = sizeof(uint32_t);
+    seqid_t id = index_next_seqid(index);
+    uint8_t idlength = sizeof(seqid_t);
 
     // setting key to existing if we do an update
     if(existing)

--- a/zdbd/commands_set.c
+++ b/zdbd/commands_set.c
@@ -138,12 +138,15 @@ static size_t redis_set_handler_sequential(redis_client_t *client, index_entry_t
     // create some easier accessors
     // grab the next id, this may be replaced
     // by user input if the key exists
-    seqid_t id = index_next_seqid(index);
+    seqid_t id = index_next_id(index);
     uint8_t idlength = sizeof(seqid_t);
 
     // setting key to existing if we do an update
-    if(existing)
+    if(existing) {
+        zdbd_debug("[+] command: set: updating existing id: ");
+        zdbd_debughex(existing->id, existing->idlength);
         memcpy(&id, existing->id, existing->idlength);
+    }
 
     unsigned char *value = request->argv[2]->buffer;
     uint32_t valuelength = request->argv[2]->length;
@@ -151,7 +154,9 @@ static size_t redis_set_handler_sequential(redis_client_t *client, index_entry_t
     // setting the timestamp
     time_t timestamp = timestamp_from_set(request);
 
-    zdbd_debug("[+] command: set: %u bytes key, %u bytes data\n", idlength, valuelength);
+    zdbd_debug("[+] command: set: sequential-key: ");
+    zdbd_debughex(&id, idlength);
+    zdbd_debug("[+] command: set: %u bytes data\n", valuelength);
 
     data_request_t dreq = {
         .data = value,
@@ -187,7 +192,7 @@ static size_t redis_set_handler_sequential(redis_client_t *client, index_entry_t
         return 0;
     }
 
-    zdbd_debug("[+] command: set: sequential-key: ");
+    zdbd_debug("[+] command: set: writing data sequential-key: ");
     zdbd_debughex(&id, idlength);
 
     zdbd_debug("[+] command: set: offset: %lu\n", offset);

--- a/zdbd/commands_system.c
+++ b/zdbd/commands_system.c
@@ -82,6 +82,8 @@ int command_info(redis_client_t *client) {
 
     len += sprintf(info + len, "\n# internals\n");
     len += sprintf(info + len, "sequential_key_size: %ld\n", sizeof(seqid_t));
+    len += sprintf(info + len, "data_version: %d\n", ZDB_DATAFILE_VERSION);
+    len += sprintf(info + len, "index_version: %d\n", ZDB_IDXFILE_VERSION);
 
     len += sprintf(info + len, "\n# stats\n");
     len += sprintf(info + len, "commands_executed: %" PRIu64 "\n", dstats->cmdsvalid);

--- a/zdbd/commands_system.c
+++ b/zdbd/commands_system.c
@@ -80,6 +80,8 @@ int command_info(redis_client_t *client) {
     len += sprintf(info + len, "\n# clients\n");
     len += sprintf(info + len, "clients_lifetime: %" PRIu32 "\n", dstats->clients);
 
+    len += sprintf(info + len, "\n# internals\n");
+    len += sprintf(info + len, "sequential_key_size: %ld\n", sizeof(seqid_t));
 
     len += sprintf(info + len, "\n# stats\n");
     len += sprintf(info + len, "commands_executed: %" PRIu64 "\n", dstats->cmdsvalid);


### PR DESCRIPTION
Major v2 update breaking lot of compatibility before releasing final v2:
- Sequential keys are now using **64 bits** and not 32 bits, this make amount of keys nearly unlimited.
- Rename database files to reduce directory size and better support of large amount of files
- Rewrite namespace header to drop `legacy` and `extended` difference

All of theses update break compatibility with old database.
This pull request implement #110  and #93