### PR TITLE
libzdb: rewrite index memory handling

### DIFF
--- a/libzdb/api.c
+++ b/libzdb/api.c
@@ -416,12 +416,12 @@ zdb_api_t *zdb_api_del(namespace_t *ns, void *key, size_t ksize) {
     return zdb_api_reply_success();
 }
 
-index_root_t *zdb_index_init_lazy(zdb_settings_t *settings, char *indexdir, void *namespace) {
-    return index_init_lazy(settings, indexdir, namespace);
+index_root_t *zdb_index_init_lazy(zdb_settings_t *settings, char *indexdir) {
+    return index_init_lazy(settings, indexdir);
 }
 
-index_root_t *zdb_index_init(zdb_settings_t *settings, char *indexdir, void *namespace, index_branch_t **branches) {
-    return index_init(settings, indexdir, namespace, branches);
+index_root_t *zdb_index_init(zdb_settings_t *settings, char *indexdir) {
+    return index_init(settings, indexdir);
 }
 
 uint64_t zdb_index_availity_check(index_root_t *root) {

--- a/libzdb/api.h
+++ b/libzdb/api.h
@@ -55,8 +55,8 @@
     int zdb_index_open_readwrite(index_root_t *root, fileid_t fileid);
     void zdb_index_close(index_root_t *zdbindex);
 
-    index_root_t *zdb_index_init_lazy(zdb_settings_t *settings, char *indexdir, void *namespace);
-    index_root_t *zdb_index_init(zdb_settings_t *settings, char *indexdir, void *namespace, index_branch_t **branches);
+    index_root_t *zdb_index_init_lazy(zdb_settings_t *settings, char *indexdir);
+    index_root_t *zdb_index_init(zdb_settings_t *settings, char *indexdir);
     uint64_t zdb_index_availity_check(index_root_t *root);
 
     // index header validity

--- a/libzdb/index_branch.c
+++ b/libzdb/index_branch.c
@@ -286,6 +286,9 @@ static void index_hash_free_list(index_entry_t *head) {
 }
 
 void index_hash_free(index_hash_t *root) {
+    if(!root)
+        return;
+
     for(int i = 0; i < ENTRIES_PER_ROWS; i++) {
         if(root->sub[i]) {
             // clean the linked list

--- a/libzdb/index_branch.h
+++ b/libzdb/index_branch.h
@@ -1,21 +1,22 @@
 #ifndef __ZDB_INDEX_BRANCH_H
     #define __ZDB_INDEX_BRANCH_H
 
-    // buckets
-    extern uint32_t buckets_branches;
-    extern uint32_t buckets_mask;
-
-    int index_set_buckets_bits(uint8_t bits);
-    index_branch_t **index_buckets_init();
-
     // initializers
-    index_branch_t *index_branch_init(index_branch_t **branches, uint32_t branchid);
-    void index_branch_free(index_branch_t **branches, uint32_t branchid);
+    index_hash_t *index_hash_init();
+    index_hash_t *index_hash_new(int type);
 
-    // accessors
-    index_branch_t *index_branch_get(index_branch_t **branches, uint32_t branchid);
-    index_branch_t *index_branch_get_allocate(index_branch_t **branches, uint32_t branchid);
-    index_entry_t *index_branch_append(index_branch_t **branches, uint32_t branchid, index_entry_t *entry);
-    index_entry_t *index_branch_remove(index_branch_t *branch, index_entry_t *entry, index_entry_t *previous);
-    index_entry_t *index_branch_get_previous(index_branch_t *branch, index_entry_t *entry);
+    // cleaner
+    void index_hash_free(index_hash_t *root);
+
+    // list manipulation
+    void *index_hash_push(index_hash_t *root, uint32_t lookup, index_entry_t *entry);
+    index_entry_t *index_hash_lookup(index_hash_t *root, uint32_t lookup);
+    index_entry_t *index_hash_remove(index_hash_t *root, uint32_t lookup, index_entry_t *entry);
+
+    // inspection
+    int index_hash_walk(index_hash_t *root, int (*callback)(index_entry_t *, void *), void *userptr);
+
+    // statistics
+    void index_hash_stats(index_hash_t *root);
+
 #endif

--- a/libzdb/index_loader.c
+++ b/libzdb/index_loader.c
@@ -16,57 +16,31 @@
 //
 // index initializer and dumper
 //
-static inline void index_dump_entry(index_entry_t *entry) {
-    zdb_log("[+] key [");
+static int index_dump_full_callback(index_entry_t *entry, void *userptr) {
+    (void) userptr;
+
+    zdb_log("[+] key: ");
     zdb_hexdump(entry->id, entry->idlength);
-    zdb_log("] offset %" PRIu32 ", length: %" PRIu32 "\n", entry->offset, entry->length);
+
+    zdb_log("[+]   offset %" PRIu32 ", length: %" PRIu32 "\n", entry->offset, entry->length);
+
+    return 0;
+}
+
+static void index_dump_full(index_root_t *root) {
+    zdb_log("[+] ===========================\n");
+
+    // walk over all keys and dump some information
+    index_hash_walk(root->hash, index_dump_full_callback, NULL);
+
+    zdb_log("[+] ===========================\n");
 }
 
 // dumps the current index load
 // fulldump flags enable printing each entry
-static void index_dump(index_root_t *root, int fulldump) {
-    size_t branches = 0;
-
+static void index_dump(index_root_t *root) {
     zdb_log("[+] index: verifyfing populated keys\n");
-
-    if(fulldump)
-        zdb_log("[+] ===========================\n");
-
-    // iterating over each buckets
-    for(uint32_t b = 0; b < buckets_branches; b++) {
-        index_branch_t *branch = index_branch_get(root->branches, b);
-
-        // skipping empty branch
-        if(!branch)
-            continue;
-
-        branches += 1;
-        index_entry_t *entry = branch->list;
-
-        if(!fulldump)
-            continue;
-
-        // iterating over the linked-list
-        for(; entry; entry = entry->next)
-            index_dump_entry(entry);
-    }
-
-    if(fulldump) {
-        if(root->stats.entries == 0)
-            zdb_log("[+] index is empty\n");
-
-        zdb_log("[+] ===========================\n");
-    }
-
-    zdb_verbose("[+] index: uses: %lu branches\n", branches);
-
-    // overhead contains:
-    // - the buffer allocated to hold each (future) branches pointer
-    // - the branch struct itself for each branch
-    size_t overhead = (buckets_branches * sizeof(index_branch_t **)) +
-                      (branches * sizeof(index_branch_t));
-
-    zdb_verbose("[+] index: memory overhead: %.2f KB (%lu bytes)\n", KB(overhead), overhead);
+    index_hash_stats(root->hash);
 }
 
 static void index_dump_statistics(index_root_t *root) {
@@ -506,7 +480,7 @@ index_seqid_t *index_allocate_seqid() {
     return seqid;
 }
 
-index_root_t *index_init_lazy(zdb_settings_t *settings, char *indexdir, void *namespace) {
+index_root_t *index_init_lazy(zdb_settings_t *settings, char *indexdir) {
     index_root_t *root;
 
     if(!(root = calloc(sizeof(index_root_t), 1))) {
@@ -524,11 +498,13 @@ index_root_t *index_init_lazy(zdb_settings_t *settings, char *indexdir, void *na
     root->synctime = settings->synctime;
     root->lastsync = 0;
     root->status = INDEX_NOT_LOADED | INDEX_HEALTHY;
-    root->branches = NULL;
-    root->namespace = namespace;
     root->mode = settings->mode;
     root->rotate = time(NULL);
     root->secure = settings->secure;
+
+    // allocate index hash
+    if(!(root->hash = index_hash_init()))
+        zdb_diep("index: init: hash");
 
     index_dirty_resize(root, 1);
 
@@ -564,18 +540,22 @@ index_root_t *index_rehash(index_root_t *root) {
 }
 
 // create an index and load files
-index_root_t *index_init(zdb_settings_t *settings, char *indexdir, void *namespace, index_branch_t **branches) {
+index_root_t *index_init(zdb_settings_t *settings, char *indexdir) {
     zdb_debug("[+] index: initializing\n");
 
-    index_root_t *root = index_init_lazy(settings, indexdir, namespace);
-    root->branches = branches;
+    index_root_t *root = index_init_lazy(settings, indexdir);
 
     // initialize internal pointers
     index_rehash(root);
     index_internal_load(root);
 
-    if(root->mode == ZDB_MODE_KEY_VALUE)
-        index_dump(root, settings->dump);
+    if(root->mode == ZDB_MODE_KEY_VALUE) {
+        if(settings->dump)
+            index_dump_full(root);
+
+        // dump internal statistics
+        index_dump(root);
+    }
 
     index_dump_statistics(root);
 
@@ -601,6 +581,9 @@ void index_destroy(index_root_t *root) {
         free(root->seqid->seqmap);
         free(root->seqid);
     }
+
+    // clean hashmap
+    index_hash_free(root->hash);
 
     free(root);
 }

--- a/libzdb/index_loader.h
+++ b/libzdb/index_loader.h
@@ -5,8 +5,8 @@
     index_header_t index_initialize(int fd, fileid_t indexid, index_root_t *root);
 
     // initialize the whole index system
-    index_root_t *index_init(zdb_settings_t *settings, char *indexdir, void *namespace, index_branch_t **branches);
-    index_root_t *index_init_lazy(zdb_settings_t *settings, char *indexdir, void *namespace);
+    index_root_t *index_init(zdb_settings_t *settings, char *indexdir);
+    index_root_t *index_init_lazy(zdb_settings_t *settings, char *indexdir);
 
     // internal functions
     index_root_t *index_rehash(index_root_t *root);

--- a/libzdb/index_set.c
+++ b/libzdb/index_set.c
@@ -182,7 +182,6 @@ index_entry_t *index_insert_memory_handler_memkey(index_root_t *root, index_set_
 
     memcpy(entry->id, set->id, new->idlength);
     entry->idlength = new->idlength;
-    entry->namespace = root->namespace;
     entry->offset = new->offset;
     entry->length = new->length;
     entry->dataid = root->indexid; // WARNING: check this
@@ -197,7 +196,10 @@ index_entry_t *index_insert_memory_handler_memkey(index_root_t *root, index_set_
     uint32_t branchkey = index_key_hash(entry->id, entry->idlength);
 
     // commit entry into memory
-    index_branch_append(root->branches, branchkey, entry);
+    if(!index_hash_push(root->hash, branchkey, entry)) {
+        free(entry);
+        return NULL;
+    }
 
     // update statistics (if the key exists)
     // maybe it doesn't exists if it comes from a replay

--- a/libzdb/namespace.c
+++ b/libzdb/namespace.c
@@ -448,7 +448,7 @@ ns_root_t *namespaces_allocate(zdb_settings_t *settings) {
     root->effective = 1;          // no namespace has been loaded yet
     root->settings = settings;    // keep the reference to the settings, needed for paths
 
-    if(!(root->namespaces = (namespace_t **) malloc(sizeof(namespace_t *) * root->length)))
+    if(!(root->namespaces = (namespace_t **) calloc(sizeof(namespace_t *), root->length)))
         zdb_diep("namespace malloc");
 
     return root;
@@ -698,6 +698,10 @@ static void namespace_flushing_hook(namespace_t *namespace) {
 
 int namespaces_emergency() {
     namespace_t *ns;
+
+    // namespace not allocated yet
+    if(namespace_iter() == NULL)
+        return 0;
 
     for(ns = namespace_iter(); ns; ns = namespace_iter_next(ns)) {
         zdb_log("[+] namespaces: flushing: %s\n", ns->name);

--- a/libzdb/namespace.c
+++ b/libzdb/namespace.c
@@ -648,9 +648,6 @@ static void namespace_delete_hook(namespace_t *namespace) {
 int namespace_delete(namespace_t *namespace) {
     zdb_log("[+] namespace: removing: %s\n", namespace->name);
 
-    // detach all clients attached to this namespace
-    // redis_detach_clients(namespace);
-
     // unallocating keys attached to this namespace
     index_clean_namespace(namespace->index);
 

--- a/libzdb/namespace.h
+++ b/libzdb/namespace.h
@@ -58,14 +58,6 @@
         size_t effective;          // amount of namespaces currently loaded
         namespace_t **namespaces;  // pointers to namespaces
         zdb_settings_t *settings;  // global settings reminder
-        index_branch_t **branches; // unique global branches list
-
-        // as explained in namespace.c, we keep a single big
-        // index which that contains everything (all namespaces together)
-        //
-        // for each index structure, we will point the branches to the
-        // same big index branches all the time, this is why we keep
-        // this one here, as the 'original one'
 
     } ns_root_t;
 

--- a/tools/index-dump/index-dump.c
+++ b/tools/index-dump/index-dump.c
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
     // zdb_open(zdb_settings);
     index_root_t *zdbindex;
 
-    if(!(zdbindex = zdb_index_init_lazy(zdb_settings, dirname, NULL))) {
+    if(!(zdbindex = zdb_index_init_lazy(zdb_settings, dirname))) {
         fprintf(stderr, "[-] index-dump: cannot load index\n");
         exit(EXIT_FAILURE);
     }

--- a/tools/index-rebuild/index-rebuild.c
+++ b/tools/index-rebuild/index-rebuild.c
@@ -293,7 +293,7 @@ int main(int argc, char *argv[]) {
         exit(EXIT_FAILURE);
     }
 
-    if(!(zdbindex = zdb_index_init(zdb_settings, namespace->indexpath, namespace, nsroot->branches))) {
+    if(!(zdbindex = zdb_index_init(zdb_settings, namespace->indexpath))) {
         fprintf(stderr, "[-] index-rebuild: cannot initialize index\n");
         exit(EXIT_FAILURE);
     }

--- a/zdbd/commands_namespace.c
+++ b/zdbd/commands_namespace.c
@@ -94,6 +94,9 @@ int command_nsdel(redis_client_t *client) {
         return 1;
     }
 
+    // detach all clients attached to this namespace
+    redis_detach_clients(namespace);
+
     // delete the new namespace
     if(namespace_delete(namespace)) {
         redis_hardsend(client, "-Could not delete this namespace");


### PR DESCRIPTION
Previous index memory management was basically one large array of 128 MB and each block of 8 bytes was a pointer to a linked-list of entries.

Each entry was the object entry with an extra link for the namespace because all namespace were sharing the same master-array.

To find the correct list index, the crc32 of the key were used and the first 24 bits was the array-id, this method was really fast but needed to maintains a unique full large shared buffer. When removing a namespace, deleting process could be very long to iterate over all keys (for all namespaces) even if namespace contains few keys.

Real memory usage was quite effcient actually, thanks Linux, only effective used pages was allocated, so the large 128 MB array was dynamically allocated by the kernel but on really large database, limit can quickly come and sharing the array was anyway not a good idea IMO.

Here is a new implementation, in test. This new implementation use a dedicated index map per namespace, the namespace pointer per entry is thus not needed anymore, it's more logic and less error prone, no sharing across namespace anymore.

When deleting a namespace, the complete isolated map can be free'd without interfering with other keys/namespace.

There is still a crc32 computing on the key and that value will point to an array entry aswell, but this array become multi-level and levels are allocated dynamically. Each level is composed of an array of 16 pointers. This version use 5 level (20 bits out of 32). This is configurable.

Test were made on 2 millions keys namespace, memory usage can be reduced up to 6 times than before and is more predictible (eg: 2 times the same namespace will use 2 times the memory). More test to come, performance doesn't seems to be affected a lot, but it's slower (lookup and allocation are slower, but difference is not really noticable).