### PR TITLE
libzdb: remove creation/opened time on header

### DIFF
--- a/libzdb/data.c
+++ b/libzdb/data.c
@@ -256,8 +256,8 @@ void data_initialize(char *filename, data_root_t *root) {
 
     memcpy(header.magic, "DAT0", 4);
     header.version = ZDB_DATAFILE_VERSION;
-    header.created = time(NULL);
-    header.opened = 0; // not supported yet
+    header.created = 0; // timestamp are not used anymore, this allows
+    header.opened = 0;  // checksum comparaison more efficient across replicat
     header.fileid = root->dataid;
 
     if(!data_write(fd, &header, sizeof(data_header_t), 1, root))

--- a/libzdb/index_loader.c
+++ b/libzdb/index_loader.c
@@ -88,9 +88,9 @@ index_header_t index_initialize(int fd, fileid_t indexid, index_root_t *root) {
 
     memcpy(header.magic, "IDX0", 4);
     header.version = ZDB_IDXFILE_VERSION;
-    header.created = time(NULL);
+    header.created = 0; // not used anymore to keep coherence
+    header.opened = 0;  // across replicat checksum
     header.fileid = indexid;
-    header.opened = time(NULL);
     header.mode = root->mode;
 
     if(!index_write(fd, &header, sizeof(index_header_t), root))
@@ -257,16 +257,18 @@ static size_t index_load_file(index_root_t *root) {
     // if the file was just created, it's okay, we have a new struct ready
     if(!(root->status & INDEX_READ_ONLY)) {
         // updating index with latest opening state
-        header.opened = time(NULL);
+        header.opened = 0;
         lseek(root->indexfd, 0, SEEK_SET);
 
         if(!index_write(root->indexfd, &header, sizeof(index_header_t), root))
             zdb_diep(root->indexfile);
     }
 
+    /*
     char date[256];
     zdb_verbose("[+] index: created at: %s\n", zdb_header_date(header.created, date, sizeof(date)));
     zdb_verbose("[+] index: last open: %s\n", zdb_header_date(header.opened, date, sizeof(date)));
+    */
 
     if(zdb_rootsettings.mode != ZDB_MODE_MIX) {
         if(header.mode != zdb_rootsettings.mode) {


### PR DESCRIPTION
Keeping track of creation and last opened time in the data/index header for each file was kinda interresting but not really useful (creation date are still recorded on filesystem level).

But this had a major downside: restarting zdb were each time changing the timestamp in the header, changing the checksum of the file, without any real change to the data. This is annoying for incremental backup.

Header fields are kept as it, but timestamp are now forced to zero. Restarting zdb don't change file checksum anymore.

This will be useful for coming upgrade with incremental replication.