### PR TITLE
core: supports incremental sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,36 +174,39 @@ This mode is not possible if you don't have any data/index already available.
 
 # Supported commands
 - `PING`
-- `SET key value [timestamp]`
-- `GET key`
-- `MGET key`
-- `DEL key`
+- `SET <key> <value> [timestamp]`
+- `GET <key>`
+- `MGET <key> [key ...]`
+- `DEL <key>`
 - `STOP` (used only for debugging, to check memory leaks)
-- `EXISTS key`
-- `CHECK key`
-- `KEYCUR key`
+- `EXISTS <key>`
+- `CHECK <key>`
+- `KEYCUR <key>`
 - `INFO`
-- `NSNEW namespace`
-- `NSDEL namespace`
-- `NSINFO namespace`
+- `NSNEW <namespace>`
+- `NSDEL <namespace>`
+- `NSINFO <namespace>`
 - `NSLIST`
-- `NSSET namespace property value`
-- `SELECT namespace [SECURE password]`
+- `NSSET <namespace> <property> <value>`
+- `SELECT <namespace> [SECURE password]`
 - `DBSIZE`
 - `TIME`
-- `AUTH password`
-- `AUTH SECURE`
-- `SCAN [optional cursor]`
-- `SCANX [optional cursor]` (this is just an alias for `SCAN`)
-- `RSCAN [optional cursor]`
+- `AUTH [password]`
+- `AUTH SECURE [password]`
+- `SCAN [cursor]`
+- `RSCAN [cursor]`
 - `WAIT command | * [timeout-ms]`
-- `HISTORY key [binary-data]`
+- `HISTORY <key> [binary-data]`
 - `FLUSH`
 - `HOOKS`
 - `INDEX DIRTY [RESET]`
-- `DATA RAW [fileid] [offset]`
+- `DATA RAW <fileid> <offset>`
+- `LENGTH <key>`
+- `KEYTIME <key>`
 
 `SET`, `GET` and `DEL`, `SCAN` and `RSCAN` supports binary keys.
+
+Arguments `<flags>` are mandatory, arguments `[flags]` are optionals.
 
 > Compared to real redis protocol, during a `SET`, the key is returned as response.
 
@@ -533,6 +536,35 @@ from another database used eg, for replication.
 
 You can use fields `data_current_id` and `data_current_offset` from `NSINFO` to query valid offsets.
 
+## LENGTH
+
+Returns payload size of a key or `(nil)` if not found.
+
+```
+> SET hello world
+"hello"
+
+> LENGTH hello
+(integer) 5
+
+> LENGTH notfound
+(nil)
+```
+
+## KEYTIME
+
+Return last-update timestamp of a key or `(nil)` if not found.
+
+```
+> SET hello world
+"hello"
+
+> KEYTIME hello
+(integer) 1664996517
+
+> KEYTIME notfound
+(nil)
+```
 
 # Namespaces
 A namespace is a dedicated directory on index and data root directory.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ This mode is not possible if you don't have any data/index already available.
 - `FLUSH`
 - `HOOKS`
 - `INDEX DIRTY [RESET]`
+- `DATA RAW [fileid] [offset]`
 
 `SET`, `GET` and `DEL`, `SCAN` and `RSCAN` supports binary keys.
 
@@ -508,6 +509,30 @@ List the current namespace index files id which were modified since last reset
 
 ### INDEX DIRTY RESET
 Reset the dirty list
+
+## DATA
+
+This command have small internal operation on raw data file.
+
+### DATA RAW
+
+An internal call allows to retreive a raw data object from database only based on fileid and offset.
+This method of access should only be made by a valid fileid and offset, some protection are in
+place to avoid issues on wrong offset but not fully tested yet.
+    
+This command (only for admin) returns an array with the object requested:
+  1. Key
+  2. Previous Offset
+  3. Integrity CRC32
+  4. Flags
+  5. Timestamp
+  6. Payload
+
+In addition with NSINFO, this command can be used to query a database based on fielid/offset
+from another database used eg, for replication.
+
+You can use fields `data_current_id` and `data_current_offset` from `NSINFO` to query valid offsets.
+
 
 # Namespaces
 A namespace is a dedicated directory on index and data root directory.

--- a/libzdb/api.c
+++ b/libzdb/api.c
@@ -401,8 +401,10 @@ zdb_api_t *zdb_api_del(namespace_t *ns, void *key, size_t ksize) {
         return zdb_api_reply(ZDB_API_DELETED, NULL);
     }
 
+    time_t timestamp = time(NULL);
+
     // update data file, flag entry deleted
-    if(!data_delete(ns->data, entry->id, entry->idlength)) {
+    if(!data_delete(ns->data, entry->id, entry->idlength, timestamp)) {
         zdb_debug("[-] api: del: deleting data failed\n");
         return zdb_api_reply(ZDB_API_INTERNAL_ERROR, NULL);
     }

--- a/libzdb/data.c
+++ b/libzdb/data.c
@@ -547,7 +547,7 @@ int data_entry_is_deleted(data_entry_header_t *entry) {
 // was deleted
 // this is needed in order to rebuild an index from data file and
 // for compaction process
-int data_delete(data_root_t *root, void *id, uint8_t idlength) {
+int data_delete(data_root_t *root, void *id, uint8_t idlength, time_t timestamp) {
     unsigned char *empty = (unsigned char *) "";
 
     data_request_t dreq = {
@@ -557,6 +557,7 @@ int data_delete(data_root_t *root, void *id, uint8_t idlength) {
         .idlength = idlength,
         .flags = DATA_ENTRY_DELETED,
         .crc = 0,
+        .timestamp = timestamp,
     };
 
     zdb_debug("[+] data: delete: insert empty flagged data\n");

--- a/libzdb/data.h
+++ b/libzdb/data.h
@@ -129,7 +129,7 @@
 
     // size_t data_match(data_root_t *root, void *id, uint8_t idlength, size_t offset, fileid_t dataid);
 
-    int data_delete(data_root_t *root, void *id, uint8_t idlength);
+    int data_delete(data_root_t *root, void *id, uint8_t idlength, time_t timestamp);
 
     // size_t data_insert(data_root_t *root, unsigned char *data, uint32_t datalength, void *vid, uint8_t idlength, uint8_t flags);
     size_t data_insert(data_root_t *root, data_request_t *source);

--- a/libzdb/data.h
+++ b/libzdb/data.h
@@ -3,6 +3,7 @@
 
     // split datafile after 256 MB
     #define ZDB_DEFAULT_DATA_MAXSIZE  256 * 1024 * 1024
+    #define ZDB_DATA_MAX_PAYLOAD      8 * 1024 * 1024
 
     // data statistics
     typedef struct data_stats_t {
@@ -73,6 +74,13 @@
 
     } data_payload_t;
 
+    typedef struct data_raw_t {
+        data_entry_header_t header;
+        uint8_t *id;
+        data_payload_t payload;
+
+    } data_raw_t;
+
     // scan internal representation
     // we use a status and a pointer to the header
     // in order to know what to do
@@ -124,6 +132,7 @@
     fileid_t data_dataid(data_root_t *root);
     void data_delete_files(char *datadir);
 
+    data_raw_t data_raw_get(data_root_t *root, fileid_t dataid, off_t offset);
     data_payload_t data_get(data_root_t *root, size_t offset, size_t length, fileid_t dataid, uint8_t idlength);
     int data_check(data_root_t *root, size_t offset, fileid_t dataid);
 

--- a/libzdb/index_loader.c
+++ b/libzdb/index_loader.c
@@ -331,6 +331,7 @@ static size_t index_load_file(index_root_t *root) {
             .offset = entry->offset,
             .flags = entry->flags,
             .idxoffset = offset,
+            .timestamp = entry->timestamp,
             .crc = entry->crc,
             .parentid = entry->parentid,
             .parentoff = entry->parentoff,

--- a/tools/incremental-update/incremental.py
+++ b/tools/incremental-update/incremental.py
@@ -1,0 +1,63 @@
+import redis
+import time
+
+class ZDBIncremental:
+    def __init__(self, master, slave):
+        self.master = redis.Redis(unix_socket_path="/tmp/zdb.sock")
+        self.slave = redis.Redis(port=9900)
+
+        # disable defaults callbacks
+        for target in [self.master, self.slave]:
+            target.set_response_callback("NSINFO", redis.client.parse_info)
+            target.set_response_callback("DEL", redis.client.bool_ok)
+            target.set_response_callback("SET", bytes)
+
+    def sync(self, master, slave):
+        raw = self.master.execute_command("DATA", "RAW", slave['dataid'], slave['offset'])
+
+        print(raw)
+
+        if raw[3] == 0:
+            # SET
+            response = self.slave.execute_command("SET", raw[0], raw[5], raw[4])
+            if response != raw[0]:
+                raise RuntimeError(f"incorrect set {response}")
+
+        else:
+            # DEL
+            self.slave.execute_command("DEL", raw[0], raw[4])
+
+
+    def run(self):
+        namespace = "default"
+
+        while True:
+            master = {}
+            slave = {}
+
+            nsmaster = self.master.execute_command("NSINFO", namespace)
+            master['dataid'] = int(nsmaster['data_current_id'])
+            master['offset'] = int(nsmaster['data_current_offset'])
+
+            nsslave = self.slave.execute_command("NSINFO", namespace)
+            slave['dataid'] = int(nsslave['data_current_id'])
+            slave['offset'] = int(nsslave['data_current_offset'])
+
+            print("master: %d:%d" % (master['dataid'], master['offset']))
+            print("slave: %d:%d" % (slave['dataid'], slave['offset']))
+
+            if slave['dataid'] > master['dataid']:
+                raise RuntimeError("slave ahead from master")
+
+            if master['dataid'] == slave['dataid']:
+                if master['offset'] == slave['offset']:
+                    print("sync, waiting")
+                    time.sleep(10)
+                    continue
+
+            self.sync(master, slave)
+
+
+if __name__ == '__main__':
+    incremental = ZDBIncremental("hello", "world")
+    incremental.run()

--- a/zdbd/commands.c
+++ b/zdbd/commands.c
@@ -138,6 +138,7 @@ static command_t commands_handlers[] = {
     {.command = "HISTORY", .handler = command_history},  // custom command to get previous version of a key
     {.command = "KEYCUR",  .handler = command_keycur},   // custom command to get cursor id from a key
     {.command = "LENGTH",  .handler = command_length},   // custom command to get value length of a key
+    {.command = "KEYTIME", .handler = command_keytime},  // custom command to get last updated timestamp of a key
 
     // query
     {.command = "INFO",    .handler = command_info},     // returns 0-db server name

--- a/zdbd/commands.c
+++ b/zdbd/commands.c
@@ -137,6 +137,7 @@ static command_t commands_handlers[] = {
     {.command = "KSCAN",   .handler = command_kscan},    // custom command to iterate over keys matching pattern
     {.command = "HISTORY", .handler = command_history},  // custom command to get previous version of a key
     {.command = "KEYCUR",  .handler = command_keycur},   // custom command to get cursor id from a key
+    {.command = "LENGTH",  .handler = command_length},   // custom command to get value length of a key
 
     // query
     {.command = "INFO",    .handler = command_info},     // returns 0-db server name

--- a/zdbd/commands.c
+++ b/zdbd/commands.c
@@ -121,6 +121,7 @@ static command_t commands_handlers[] = {
     {.command = "AUTH",    .handler = command_auth},     // custom AUTH command to authentifcate admin
     {.command = "HOOKS",   .handler = command_hooks},    // custom HOOKS command to list running hooks
     {.command = "INDEX",   .handler = command_index},    // custom INDEX command to query internal index
+    {.command = "DATA",    .handler = command_data},     // custom DATA command to query internal data
 
     // dataset
     {.command = "SET",     .handler = command_set},      // default SET command

--- a/zdbd/commands.h
+++ b/zdbd/commands.h
@@ -21,4 +21,8 @@
 
     int command_error_locked(redis_client_t *client);
     int command_error_frozen(redis_client_t *client);
+
+    // defined in commands_set.c
+    // used by commands_set.c and commands_dataset.c
+    time_t timestamp_from_set(resp_request_t *request, int field);
 #endif

--- a/zdbd/commands_dataset.c
+++ b/zdbd/commands_dataset.c
@@ -87,8 +87,8 @@ int command_check(redis_client_t *client) {
     }
 
     // key found and valid, let's checking the contents
-    zdbd_debug("[+] command: get: entry found, flags: %x, data length: %" PRIu32 "\n", entry->flags, entry->length);
-    zdbd_debug("[+] command: get: data file: %d, data offset: %" PRIu32 "\n", entry->dataid, entry->offset);
+    zdbd_debug("[+] command: check: entry found, flags: %x, data length: %" PRIu32 "\n", entry->flags, entry->length);
+    zdbd_debug("[+] command: check: data file: %d, data offset: %" PRIu32 "\n", entry->dataid, entry->offset);
 
     data_root_t *data = client->ns->data;
     int status = data_check(data, entry->offset, entry->dataid);

--- a/zdbd/commands_dataset.c
+++ b/zdbd/commands_dataset.c
@@ -181,3 +181,48 @@ int command_del(redis_client_t *client) {
     return 0;
 }
 
+int command_length(redis_client_t *client) {
+    resp_request_t *request = client->request;
+
+    if(!command_args_validate(client, 2))
+        return 1;
+
+    if(request->argv[1]->length > MAX_KEY_LENGTH) {
+        zdb_log("[-] command: length: invalid key size\n");
+        redis_hardsend(client, "-Invalid key");
+        return 1;
+    }
+
+    if(namespace_is_frozen(client->ns))
+        return command_error_frozen(client);
+
+    zdbd_debug("[+] command: length: lookup key: ");
+    zdbd_debughex(request->argv[1]->buffer, request->argv[1]->length);
+
+    index_root_t *index = client->ns->index;
+    index_entry_t *entry = index_get(index, request->argv[1]->buffer, request->argv[1]->length);
+
+    // key not found at all
+    if(!entry) {
+        zdbd_debug("[-] command: length: key not found\n");
+        redis_hardsend(client, "$-1");
+        return 1;
+    }
+
+    // key found but deleted
+    if(entry->flags & INDEX_ENTRY_DELETED) {
+        zdbd_verbose("[-] command: length: key deleted\n");
+        redis_hardsend(client, "$-1");
+        return 1;
+    }
+
+    zdbd_debug("[+] command: length: entry found, flags: %x, data length: %" PRIu32 "\n", entry->flags, entry->length);
+
+    char response[32];
+    sprintf(response, ":%" PRIu32 "\r\n", entry->length);
+
+    redis_reply_stack(client, response, strlen(response));
+
+    return 0;
+}
+

--- a/zdbd/commands_dataset.h
+++ b/zdbd/commands_dataset.h
@@ -5,4 +5,5 @@
     int command_check(redis_client_t *client);
     int command_del(redis_client_t *client);
     int command_length(redis_client_t *client);
+    int command_keytime(redis_client_t *client);
 #endif

--- a/zdbd/commands_dataset.h
+++ b/zdbd/commands_dataset.h
@@ -4,4 +4,5 @@
     int command_exists(redis_client_t *client);
     int command_check(redis_client_t *client);
     int command_del(redis_client_t *client);
+    int command_length(redis_client_t *client);
 #endif

--- a/zdbd/commands_namespace.c
+++ b/zdbd/commands_namespace.c
@@ -361,6 +361,11 @@ int command_nsinfo(redis_client_t *client) {
         len += sprintf(info + len, "data_active: %s\n", namespace->data->datafile);
         len += sprintf(info + len, "index_path: %s\n", namespace->index->indexdir);
         len += sprintf(info + len, "index_active: %s\n", namespace->index->indexfile);
+
+        off_t offset = lseek(namespace->data->datafd, 0, SEEK_END);
+
+        len += sprintf(info + len, "data_current_id: %d\n", namespace->data->dataid);
+        len += sprintf(info + len, "data_current_offset: %lu\n", offset);
     }
 
     redis_bulk_t response = redis_bulk(info, len);

--- a/zdbd/commands_namespace.c
+++ b/zdbd/commands_namespace.c
@@ -641,3 +641,4 @@ int command_flush(redis_client_t *client) {
 
     return 0;
 }
+

--- a/zdbd/commands_set.c
+++ b/zdbd/commands_set.c
@@ -13,13 +13,13 @@
 #include "commands.h"
 #include "commands_get.h"
 
-static time_t timestamp_from_set(resp_request_t *request) {
+time_t timestamp_from_set(resp_request_t *request, int field) {
     // no timestamp on request, setting current time
-    if(request->argc == 3)
+    if(request->argc == field)
         return time(NULL);
 
     // convert argument to string
-    char *temp = strndup(request->argv[3]->buffer, request->argv[3]->length);
+    char *temp = strndup(request->argv[field]->buffer, request->argv[field]->length);
     time_t timestamp = atoll(temp);
     free(temp);
 
@@ -46,7 +46,7 @@ static size_t redis_set_handler_userkey(redis_client_t *client, index_entry_t *e
     uint32_t valuelength = request->argv[2]->length;
 
     // setting the timestamp
-    time_t timestamp = timestamp_from_set(request);
+    time_t timestamp = timestamp_from_set(request, 3);
 
     zdbd_debug("[+] command: set: %u bytes key, %u bytes data\n", idlength, valuelength);
     // printf("[+] set key: %.*s\n", idlength, id);
@@ -154,7 +154,7 @@ static size_t redis_set_handler_sequential(redis_client_t *client, index_entry_t
     uint32_t valuelength = request->argv[2]->length;
 
     // setting the timestamp
-    time_t timestamp = timestamp_from_set(request);
+    time_t timestamp = timestamp_from_set(request, 3);
 
     zdbd_debug("[+] command: set: sequential-key: ");
     zdbd_debughex(&id, idlength);

--- a/zdbd/commands_system.h
+++ b/zdbd/commands_system.h
@@ -9,4 +9,5 @@
 
     int command_hooks(redis_client_t *client);
     int command_index(redis_client_t *client);
+    int command_data(redis_client_t *client);
 #endif


### PR DESCRIPTION
This pull request is an early adoption of a new way to synchronize database incrementally.
Some features:
- Ensure checksum of index/data files doesn't change across zdb restart
  - Restarting zdb was updating a timestamp on database headers, changing checksum after restart even if data didn't changed.
- Add new commands to know and keep track of current database position
- Add commands to fetch raw entry data