### PR TITLE
libzdb: fix invalid RSCAN on sequential database

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ This mode is not possible if you don't have any data/index already available.
 - `NSINFO namespace`
 - `NSLIST`
 - `NSSET namespace property value`
+- `NSJUMP`
 - `SELECT namespace [SECURE password]`
 - `DBSIZE`
 - `TIME`
@@ -362,6 +363,9 @@ denied with an error message (eg: `Namespace is temporarily locked`).
 
 `FREEZE` mode will deny any operation on the specific namespace, read, write, update, delete operations
 will be denied with an error message (eg: `Namespace is temporarily frozen`)
+
+## NSJUMP
+Force closing current index and data files and open the next id.
 
 ## SELECT
 Change your current namespace. If the requested namespace is password-protected, you need

--- a/libzdb/index.c
+++ b/libzdb/index.c
@@ -25,7 +25,7 @@ void index_item_header_dump(index_item_t *item) {
     zdb_debug("[+] index: item dump: data fileid: %" PRIu32 "\n", item->dataid);
     zdb_debug("[+] index: item dump: data offset: %" PRIu32 "\n", item->offset);
     zdb_debug("[+] index: item dump: data length: %" PRIu32 "\n", item->length);
-    zdb_debug("[+] index: item dump: previous   : %" PRIx32 "\n", item->previous);
+    zdb_debug("[+] index: item dump: previous   : %" PRIu32 "\n", item->previous);
     zdb_debug("[+] index: item dump: flags      : %" PRIu8  "\n", item->flags);
     zdb_debug("[+] index: item dump: timestamp  : %" PRIu32 "\n", item->timestamp);
     zdb_debug("[+] index: item dump: parent id  : %" PRIu32 "\n", item->parentid);

--- a/zdbd/commands.c
+++ b/zdbd/commands.c
@@ -148,6 +148,7 @@ static command_t commands_handlers[] = {
     {.command = "NSLIST",  .handler = command_nslist},   // custom command to list namespaces
     {.command = "NSSET",   .handler = command_nsset},    // custom command to edit namespace settings
     {.command = "NSINFO",  .handler = command_nsinfo},   // custom command to get namespace information
+    {.command = "NSJUMP",  .handler = command_nsjump},   // custom command to force jumping to next index/data
     {.command = "SELECT",  .handler = command_select},   // default SELECT (with pwd) namespace switch
     {.command = "RELOAD",  .handler = command_reload},   // custom command to reload a namespace
     {.command = "FLUSH",   .handler = command_flush},    // custom command to reset a namespace

--- a/zdbd/commands_namespace.c
+++ b/zdbd/commands_namespace.c
@@ -577,6 +577,21 @@ int command_nsset(redis_client_t *client) {
     return 0;
 }
 
+int command_nsjump(redis_client_t *client) {
+    // command restricted to admin only
+    if(!command_admin_authorized(client))
+        return 1;
+
+    zdbd_debug("[+] command: nsjump: forcing index and data jump\n");
+
+    size_t newid = index_jump_next(client->ns->index);
+    data_jump_next(client->ns->data, newid);
+
+    redis_hardsend(client, "+OK");
+
+    return 0;
+}
+
 int command_dbsize(redis_client_t *client) {
     char response[64];
 

--- a/zdbd/commands_namespace.h
+++ b/zdbd/commands_namespace.h
@@ -7,6 +7,7 @@
     int command_nslist(redis_client_t *client);
     int command_nsinfo(redis_client_t *client);
     int command_nsset(redis_client_t *client);
+    int command_nsjump(redis_client_t *client);
     int command_dbsize(redis_client_t *client);
     int command_reload(redis_client_t *client);
     int command_flush(redis_client_t *client);


### PR DESCRIPTION
From issue #146, `RSCAN` is not returning sane data in sequential database. This is caused by old dirty code supposed to fix mistake on old database, we drop that support since it's not used and probably not in the field and if it it, please migrate your database to a new version.