### PR TITLE
actions: update versions and image

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -4,7 +4,8 @@ on: [push]
 jobs:
   debug:
     name: Create debug artifacts
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master
@@ -45,7 +46,8 @@ jobs:
 
   release:
     name: Create release artifacts
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -68,6 +68,8 @@ jobs:
       - name: Get versions
         id: versions
         run: |
+          echo "${GITHUB_SHA}"
+          echo "${GITHUB_REF}"
           echo "branch=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
           echo "commit=${GITHUB_SHA:0:10}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -50,8 +50,8 @@ jobs:
     container:
       image: ubuntu:18.04
       env:
-        GITHUB_REF: ${{ env.GITHUB_REF }}
-        GITHUB_SHA: ${{ env.GITHUB_SHA }}
+        GITHUB_REF: ${{ github.GITHUB_REF }}
+        GITHUB_SHA: ${{ github.sha }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -5,7 +5,11 @@ jobs:
   debug:
     name: Create debug artifacts
     runs-on: ubuntu-latest
-    container: ubuntu:18.04
+    container:
+      image: ubuntu:18.04
+      env:
+        GITHUB_REF: ${{ github.ref }}
+        GITHUB_SHA: ${{ github.sha }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master
@@ -18,8 +22,8 @@ jobs:
       - name: Get versions
         id: versions
         run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/*/})"
-          echo "##[set-output name=commit;]$(echo ${GITHUB_SHA:0:10})"
+          echo "branch=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
+          echo "commit=${GITHUB_SHA:0:10}" >> "$GITHUB_OUTPUT"
 
       - name: Building 0-db
         run: |
@@ -50,7 +54,7 @@ jobs:
     container:
       image: ubuntu:18.04
       env:
-        GITHUB_REF: ${{ github.GITHUB_REF }}
+        GITHUB_REF: ${{ github.ref }}
         GITHUB_SHA: ${{ github.sha }}
     steps:
       - name: Checkout the repository

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -60,8 +60,8 @@ jobs:
       - name: Get versions
         id: versions
         run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/*/})"
-          echo "##[set-output name=commit;]$(echo ${GITHUB_SHA:0:10})"
+          echo "branch=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
+          echo "commit=${GITHUB_SHA:0:10}" >> "$GITHUB_OUTPUT"
 
       - name: Building 0-db
         run: |

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -23,13 +23,13 @@ jobs:
 
       - name: Building 0-db
         run: |
-          pushd libzdb
+          cd libzdb
           make
-          popd
+          cd ..
 
-          pushd zdbd
+          cd zdbd
           make STATIC=1
-          popd
+          cd ..
 
           make
 
@@ -65,13 +65,13 @@ jobs:
 
       - name: Building 0-db
         run: |
-          pushd libzdb
+          cd libzdb
           make release
-          popd
+          cd ..
 
-          pushd zdbd
+          cd zdbd
           make release STATIC=1
-          popd
+          cd ..
 
           make
 

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Get versions
         id: versions
+        shell: bash
         run: |
           echo "branch=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
           echo "commit=${GITHUB_SHA:0:10}" >> "$GITHUB_OUTPUT"
@@ -67,9 +68,8 @@ jobs:
 
       - name: Get versions
         id: versions
+        shell: bash
         run: |
-          echo "${GITHUB_SHA}"
-          echo "${GITHUB_REF}"
           echo "branch=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
           echo "commit=${GITHUB_SHA:0:10}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -12,8 +12,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential git
+          apt-get update
+          apt-get install -y build-essential git
 
       - name: Get versions
         id: versions
@@ -54,8 +54,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential git
+          apt-get update
+          apt-get install -y build-essential git
 
       - name: Get versions
         id: versions

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -47,7 +47,11 @@ jobs:
   release:
     name: Create release artifacts
     runs-on: ubuntu-latest
-    container: ubuntu:18.04
+    container:
+      - image: ubuntu:18.04
+      - env:
+          GITHUB_REF: ${{ env.GITHUB_REF }}
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master
@@ -60,8 +64,8 @@ jobs:
       - name: Get versions
         id: versions
         run: |
-          echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> "$GITHUB_OUTPUT"
-          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "branch=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
+          echo "commit=${GITHUB_SHA:0:10}" >> "$GITHUB_OUTPUT"
 
       - name: Building 0-db
         run: |

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -48,10 +48,10 @@ jobs:
     name: Create release artifacts
     runs-on: ubuntu-latest
     container:
-      - image: ubuntu:18.04
-      - env:
-          GITHUB_REF: ${{ env.GITHUB_REF }}
-          GITHUB_SHA: ${{ env.GITHUB_SHA }}
+      image: ubuntu:18.04
+      env:
+        GITHUB_REF: ${{ env.GITHUB_REF }}
+        GITHUB_SHA: ${{ env.GITHUB_SHA }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -60,8 +60,8 @@ jobs:
       - name: Get versions
         id: versions
         run: |
-          echo "branch=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
-          echo "commit=${GITHUB_SHA:0:10}" >> "$GITHUB_OUTPUT"
+          echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> "$GITHUB_OUTPUT"
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Building 0-db
         run: |


### PR DESCRIPTION
Ubuntu version were outdated to runs on GitHub Actions, but is needed to produce a working build easy to distribute. In addition, set-output were deprecated, this fix it.