### PR TITLE
libzdb: data: avoid fragmentation of data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,17 @@ You can build each parts separatly by running `make` in each separated directori
 # Running
 
 0-db is made to be run in network server mode (using zdbd), documentation here is about the server.
-More documentation will comes about the library itself. The library is fresh new and lack of documentation.
-
-## Default port
-0-db listens by default on port `9900` but this can be overidden on the commandline using `--port` option.
+More documentation will comes about the library itself. The library lacks of documentation.
 
 Without argument, datafiles and indexfiles will be stored on the current working directory, inside
 `zdb-data` and `zdb-index` directories.
+
+It's recommended to store index on SSD, data can be stored on HDD, fragmentation will be avoided as much
+as possible (only on Linux). Please avoid CoW (Copy-on-Write) for both index and data.
+
+## Default port
+
+0-db listens by default on port `9900` but this can be overidden on the commandline using `--port` option.
 
 # Always append
 Data file (files which contains everything, included payload) are **in any cases** always append:

--- a/libzdb/data.c
+++ b/libzdb/data.c
@@ -253,10 +253,12 @@ void data_initialize(char *filename, data_root_t *root) {
         zdb_diep(filename);
     }
 
-    // pre-allocate data size to avoid fragmentation
+    #ifdef __linux__
+    // pre-allocate data size to avoid fragmentation, only on Linux
     zdb_settings_t *settings = zdb_settings_get();
     if(fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, settings->datasize) < 0)
         zdb_warnp(filename);
+    #endif
 
     // writing initial header
     data_header_t header;

--- a/libzdb/data.c
+++ b/libzdb/data.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -250,6 +252,11 @@ void data_initialize(char *filename, data_root_t *root) {
 
         zdb_diep(filename);
     }
+
+    // pre-allocate data size to avoid fragmentation
+    zdb_settings_t *settings = zdb_settings_get();
+    if(fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, settings->datasize) < 0)
+        zdb_warnp(filename);
 
     // writing initial header
     data_header_t header;


### PR DESCRIPTION
Main idea of zdb was initially to be efficient on HDD, current implementation was doing always-append but per namespace, which means random write to different namespace at the same time would eventually produce fragmentation.

New implementation ensure data are (lazily) pre-allocated using `fallocate` by reserving blocks when creating data file.